### PR TITLE
docs: improve demo in docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules/
 **/*.styl
 **/*.html
 .eslintrc.js
+!.vitepress

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,59 +1,51 @@
 const componentsJson = require('../../src/packages/components.json')
-const genZhPath = comp => ({
+const genZhPath = (comp) => ({
   text: `${comp.text}`,
   link: `/zh-CN/components${comp.path}`,
   name: `${comp.name}`,
 })
 
-const genEnPath = comp => ({
+const genEnPath = (comp) => ({
   name: `${comp.text}`,
   link: `/en-US/components${comp.path}`,
   text: `${comp.name}`,
 })
 
-const componenSidebar = (pathGenor) => (
-  {
-    name: 'components',
-    text: 'COMPONENTS',
-    children: [
-      {
-        text: 'Basic',
-        children: [
-          ...componentsJson[0].list.map(pathGenor),
-        ],
-      }, {
-        text: 'Feedback',
-        children: [
-          ...componentsJson[2].list.map(pathGenor),
-        ],
-      }, {
-        text: 'Business',
-        children: [
-          ...componentsJson[1].list.map(pathGenor),
-        ],
-      }, {
-        text: 'Form',
-        children: [
-          ...componentsJson[3].list.map(pathGenor),
-        ],
-      }, {
-        text: 'Gesture',
-        children: [
-          ...componentsJson[4].list.map(pathGenor),
-        ],
-      }
-    ]
-  }
-)
+const componenSidebar = (pathGenor) => ({
+  name: 'components',
+  text: 'COMPONENTS',
+  children: [
+    {
+      text: 'Basic',
+      children: [...componentsJson[0].list.map(pathGenor)],
+    },
+    {
+      text: 'Feedback',
+      children: [...componentsJson[2].list.map(pathGenor)],
+    },
+    {
+      text: 'Business',
+      children: [...componentsJson[1].list.map(pathGenor)],
+    },
+    {
+      text: 'Form',
+      children: [...componentsJson[3].list.map(pathGenor)],
+    },
+    {
+      text: 'Gesture',
+      children: [...componentsJson[4].list.map(pathGenor)],
+    },
+  ],
+})
 
 const zhComponentsSidebarConfig = [
   {
     text: '更新日志',
-    link: '/zh-CN/components/'
+    link: '/zh-CN/components/',
   },
   {
     text: '快速开始',
-    link: '/zh-CN/components/quick-start'
+    link: '/zh-CN/components/quick-start',
   },
   componenSidebar(genZhPath),
 ]
@@ -66,11 +58,43 @@ module.exports = {
   title: 'Mand Mobile',
   description: 'mand mobile doc',
   head: [
-    ['link', { rel: 'icon', type: 'image/png', href: '/mand-mobile-next/favicon.png' }],
-    ['link', { rel: 'dns-prefetch', href: 'https://fonts.gstatic.com' }],
-    ['link', { rel: 'preconnect', crossorigin: 'anonymous', href: 'https://fonts.gstatic.com' }],
-    ['link', { href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@200;400;500&family=Inter:wght@200;400;500;600', rel: 'stylesheet' }],
-    ['link', { rel: 'stylesheet', href: '/mand-mobile-next/mand-mobile-next.min.css' }],
+    [
+      'link',
+      {
+        rel: 'icon',
+        type: 'image/png',
+        href: '/mand-mobile-next/favicon.png',
+      },
+    ],
+    [
+      'link',
+      {
+        rel: 'dns-prefetch',
+        href: 'https://fonts.gstatic.com',
+      },
+    ],
+    [
+      'link',
+      {
+        rel: 'preconnect',
+        crossorigin: 'anonymous',
+        href: 'https://fonts.gstatic.com',
+      },
+    ],
+    [
+      'link',
+      {
+        href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@200;400;500&family=Inter:wght@200;400;500;600',
+        rel: 'stylesheet',
+      },
+    ],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: '/mand-mobile-next/mand-mobile-next.min.css',
+      },
+    ],
   ],
   lang: 'zh-CN',
   themeConfig: {
@@ -82,32 +106,38 @@ module.exports = {
     nav: [
       { text: '组件', link: '/zh-CN/components/' },
       { text: 'RoadMap', link: '/roadmap' },
-      { text: '2.x', link: 'https://didi.github.io/mand-mobile/' }
+      {
+        text: '2.x',
+        link: 'https://didi.github.io/mand-mobile/',
+      },
     ],
     navEn: [
       { text: 'Components', link: '/en-US/components/' },
       { text: 'RoadMap', link: '/roadmap' },
-      { text: '2.x', link: 'https://didi.github.io/mand-mobile/' }
+      {
+        text: '2.x',
+        link: 'https://didi.github.io/mand-mobile/',
+      },
     ],
     sidebar: {
-      '/zh-CN/components/': [ ...zhComponentsSidebarConfig ],
+      '/zh-CN/components/': [...zhComponentsSidebarConfig],
       '/en-US/components/': [
         {
           text: 'Changelog',
-          link: '/en-US/components/'
+          link: '/en-US/components/',
         },
         {
           text: 'QuickStart',
-          link: '/en-US/components/quick-start'
+          link: '/en-US/components/quick-start',
         },
         componenSidebar(genEnPath),
-      ]
-    }
+      ],
+    },
   },
 
   markdown: {
     config: (md) => {
       md.use(require('./plugins/demo'))
-    }
-  }
+    },
+  },
 }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -105,7 +105,6 @@ module.exports = {
     logo: 'https://pt-starimg.didistatic.com/static/starimg/img/ySOsAunfGm1610683661213.png',
     nav: [
       { text: '组件', link: '/zh-CN/components/' },
-      { text: 'RoadMap', link: '/roadmap' },
       {
         text: '2.x',
         link: 'https://didi.github.io/mand-mobile/',
@@ -113,7 +112,6 @@ module.exports = {
     ],
     navEn: [
       { text: 'Components', link: '/en-US/components/' },
-      { text: 'RoadMap', link: '/roadmap' },
       {
         text: '2.x',
         link: 'https://didi.github.io/mand-mobile/',

--- a/docs/.vitepress/plugins/demo.js
+++ b/docs/.vitepress/plugins/demo.js
@@ -1,6 +1,8 @@
-const { highlight } = require('vitepress/dist/node/markdown/plugins/highlight')
+const {
+  highlight,
+} = require('vitepress/dist/node/markdown/plugins/highlight')
 const fs = require('fs')
-const klawSync =require('klaw-sync')
+const klawSync = require('klaw-sync')
 const anchor = '&-&'
 /**
  * @type {(md: import('markdown-it')) => void}
@@ -8,25 +10,49 @@ const anchor = '&-&'
 module.exports = function demoPlugin(md) {
   const RE = /^<(script|style)(?=(\s|>|$))/i
   const DEMO_RE = /^<demo-wrapper\s+.+\s+\/?/
-  const DEMO_PATH_RE = /src=("|')src\/packages\/[A-z]+-?[A-z]+\/demo("|')/
+  const DEMO_PATH_RE =
+    /src=("|')src\/packages\/[A-z]+-?[A-z]+\/demo("|')/
 
   md.renderer.rules.html_block = (tokens, idx) => {
     const content = tokens[idx].content
     const data = md.__data
-    const hoistedTags = data.hoistedTags || (data.hoistedTags = [])
+    const hoistedTags =
+      data.hoistedTags || (data.hoistedTags = [])
 
     if (RE.test(content.trim())) {
       hoistedTags.push(content)
       return ''
     } else {
       if (DEMO_RE.test(content.trim())) {
-        const { demoCodeStrs, demoCodeRaws } = demoFileHtmlStr(getDemoTruePath(content.trim()))
-        return content.replace('<demo-wrapper', `
+        const demoPath = getDemoTruePath(content.trim())
+        const { demoCodeStrs, demoCodeRaws } =
+          demoFileHtmlStr(demoPath)
+
+        const item = `
+          <script>
+            const demos = import.meta.globEager('../../../${demoPath}/demo*.vue')
+            export default {
+              data() {
+                return { demos }
+              }
+            }
+          </script>
+          `
+        if (!hoistedTags.includes(item)) {
+          hoistedTags.push(item)
+        }
+
+        return content.replace(
+          '<demo-wrapper',
+          `
           <demo-wrapper
             htmlStrs=${demoCodeStrs.join(anchor)}
             codeStrs=${demoCodeRaws.join(anchor)}
-        `)
+            :demos="demos"
+        `
+        )
       }
+
       return content
     }
   }
@@ -35,7 +61,9 @@ module.exports = function demoPlugin(md) {
    * @type  {(content: string) => string}
    */
   function getDemoTruePath(content) {
-    const demoPath = content.match(DEMO_PATH_RE)?.[0]?.split('"')[1]
+    const demoPath = content
+      .match(DEMO_PATH_RE)?.[0]
+      ?.split('"')[1]
     return demoPath
   }
 
@@ -47,18 +75,22 @@ module.exports = function demoPlugin(md) {
       nodir: true,
       depthLimit: 0,
     })
-      .filter(p => !p.path.endsWith('index.vue'))
-      .map(p => p.path)
+      .filter((p) => !p.path.endsWith('index.vue'))
+      .map((p) => p.path)
 
-    const demoCodeStrs = demoEntries.map(p => {
+    const demoCodeStrs = demoEntries.map((p) => {
       const codeStr = fs.readFileSync(p, 'utf-8')
-      const htmlStr = encodeURIComponent(highlight(codeStr, 'vue'))
+      const htmlStr = encodeURIComponent(
+        highlight(codeStr, 'vue')
+      )
 
       return htmlStr.replace(/\'/g, '&')
     })
 
-    const demoCodeRaws = demoEntries.map(p => {
-      return encodeURIComponent(fs.readFileSync(p, 'utf-8')).replace(/\'/g, '&')
+    const demoCodeRaws = demoEntries.map((p) => {
+      return encodeURIComponent(
+        fs.readFileSync(p, 'utf-8')
+      ).replace(/\'/g, '&')
     })
 
     return { demoCodeStrs, demoCodeRaws }

--- a/docs/.vitepress/theme/components/DemoWrapper.vue
+++ b/docs/.vitepress/theme/components/DemoWrapper.vue
@@ -10,28 +10,36 @@ const props = defineProps({
 })
 
 const comps = props.demos
-  ? Object
-    .entries(props.demos)
-    .map((demo) => (shallowReactive({
-      component: demo[1].default,
-      showCodeExample: false,
-      copied: false,
-    })))
+  ? Object.entries(props.demos).map((demo) =>
+      shallowReactive({
+        component: demo[1].default,
+        showCodeExample: false,
+        copied: false,
+      })
+    )
   : []
 
 const anchor = '&-&'
 
-const decodedHtmlStrs = computed(() =>
-  [...props.htmlStrs.split(anchor).map(html => decodeURIComponent(html.replace(/\&/g, "'")))]
-)
+const decodedHtmlStrs = computed(() => [
+  ...props.htmlStrs
+    .split(anchor)
+    .map((html) =>
+      decodeURIComponent(html.replace(/\&/g, "'"))
+    ),
+])
 
-const decodeCodeRaws = computed(() =>
-  [...props.codeStrs.split(anchor).map(html => decodeURIComponent(html.replace(/\&/g, "'")))]
-)
+const decodeCodeRaws = computed(() => [
+  ...props.codeStrs
+    .split(anchor)
+    .map((html) =>
+      decodeURIComponent(html.replace(/\&/g, "'"))
+    ),
+])
 
 const copyHandler = (index: number) => {
   const { text, copy, copied, isSupported } = useClipboard({
-    source: decodeCodeRaws.value[index]
+    source: decodeCodeRaws.value[index],
   })
 
   isSupported && copy()
@@ -44,16 +52,20 @@ const copyHandler = (index: number) => {
   }, 2000)
 }
 
-
 const { frontmatter } = useData()
 const name = frontmatter.value.component
 </script>
 
 <template>
   <ClientOnly>
-    <article class="
-      demo-wrapper flex flex-col m-auto 
-      <lg:justify-center lg:justify-between"
+    <article
+      class="
+        demo-wrapper
+        flex flex-col
+        m-auto
+        <lg:justify-center
+        lg:justify-between
+      "
       :class="`${name}-demo`"
       v-bind="$attrs"
     >
@@ -63,25 +75,40 @@ const name = frontmatter.value.component
         class="
           md-example-section
           flex flex-col
-          mb-16 rounded-lg border-1 border-primary border-solid
+          mb-16
+          rounded-lg
+          border-1 border-primary border-solid
           last:mb-0
         "
       >
         <div
           class="
-            md-example-title text-lg py-2 px-2 font-600
+            md-example-title
+            text-lg
+            py-2
+            px-2
+            font-600
             <sm:text-md
           "
           v-text="demo.component.title"
         ></div>
         <div
           v-if="demo.component.describe"
-          class="md-example-describe text-md my-1 <sm:text-xs <sm:my-1 "
+          class="
+            md-example-describe
+            text-md
+            my-1
+            <sm:text-xs
+            <sm:my-1
+          "
           v-text="demo.component.describe"
         ></div>
-        <div class="
+        <div
+          class="
             md-example-content
-            flex-1 px-32 py-12
+            flex-1
+            px-32
+            py-12
             <sm:p-4
           "
         >
@@ -89,36 +116,50 @@ const name = frontmatter.value.component
             <component :is="demo.component"></component>
           </div>
         </div>
-        <div class="operations relative py-2 px-2 text-center">
+        <div
+          class="operations relative py-2 px-2 text-center"
+        >
           <fluent:clipboard-code-24-regular
             class="text-md cursor-pointer <sm:text-sm"
             @click="copyHandler(index)"
           />
           <ant-design:code-outlined
             class="text-md cursor-pointer ml-12 <sm:text-sm"
-            :class="[ demo.showCodeExample? 'active-code' : '']"
-            @click="demo.showCodeExample = !demo.showCodeExample"
+            :class="[
+              demo.showCodeExample ? 'active-code' : '',
+            ]"
+            @click="
+              demo.showCodeExample = !demo.showCodeExample
+            "
           />
 
           <transition name="fade">
             <span
               v-show="demo.copied"
               class="
-                block absolute left-1/2 top-0
-                text-xs text-blue-500 bg-blue-gray-50
+                block
+                absolute
+                left-1/2
+                top-0
+                text-xs text-blue-500
+                bg-blue-gray-50
                 rounded-md
                 shadow-sm
               "
-              style="padding: 4px 10px; z-index: 999; transform: translate(-96%, -80%);"
-            >复制成功!</span>
+              style="
+                padding: 4px 10px;
+                z-index: 999;
+                transform: translate(-96%, -80%);
+              "
+              >复制成功!</span
+            >
           </transition>
         </div>
         <div
           v-if="demo.showCodeExample"
           class="md-example-code language-vue"
           v-html="decodedHtmlStrs[index]"
-        >
-        </div>
+        ></div>
       </div>
     </article>
   </ClientOnly>
@@ -194,5 +235,5 @@ const name = frontmatter.value.component
   ol, li, ul, p
     padding 0
     margin 0
-    list-style none  
+    list-style none
 </style>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:lib": "esno ./scripts/esbuild.ts",
     "build": "rm -rf dist && esno ./scripts/gen-dts.ts && yarn build:bundle && yarn build:lib",
     "build:example": "vite build --base=./",
-    "docs:dev": "vitepress dev docs --host",
+    "docs:dev": "npx esno scripts/gen-docs.ts && esno ./scripts/dev-docs.ts",
     "dev:docs": "npx esno scripts/gen-docs.ts && esno ./scripts/dev-docs.ts",
     "docs:build": "npx esno scripts/gen-docs.ts && cp dist/es/mand-mobile-next.min.css docs/public && vitepress build docs",
     "docs:serve": "vitepress serve docs",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "build": "rm -rf dist && esno ./scripts/gen-dts.ts && yarn build:bundle && yarn build:lib",
     "build:example": "vite build --base=./",
     "docs:dev": "npx esno scripts/gen-docs.ts && esno ./scripts/dev-docs.ts",
-    "dev:docs": "npx esno scripts/gen-docs.ts && esno ./scripts/dev-docs.ts",
     "docs:build": "npx esno scripts/gen-docs.ts && cp dist/es/mand-mobile-next.min.css docs/public && vitepress build docs",
     "docs:serve": "vitepress serve docs",
     "serve": "vite preview",

--- a/src/packages/action-bar/README.en-US.md
+++ b/src/packages/action-bar/README.en-US.md
@@ -25,12 +25,7 @@ ActionBar is fixed at the bottom of the page by `position: fixed`. In order to a
 
 <demo-wrapper
   src="src/packages/action-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/action-bar/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 

--- a/src/packages/action-bar/README.md
+++ b/src/packages/action-bar/README.md
@@ -27,12 +27,7 @@ Vue.createApp().component(ActionBar.name, ActionBar)
 
 <demo-wrapper
   src="src/packages/action-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/action-bar/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/action-sheet/README.en-US.md
+++ b/src/packages/action-sheet/README.en-US.md
@@ -23,12 +23,7 @@ this.$actionsheet.create({ /* ... */ }) // Totally Import
 
 <demo-wrapper
   src="src/packages/action-sheet/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/action-sheet/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 

--- a/src/packages/action-sheet/README.md
+++ b/src/packages/action-sheet/README.md
@@ -22,12 +22,7 @@ this.$actionsheet.create({ /* ... */ }) // 全量引入
 
 <demo-wrapper
   src="src/packages/action-sheet/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/action-sheet/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/activity-indicator/README.en-US.md
+++ b/src/packages/activity-indicator/README.en-US.md
@@ -21,12 +21,7 @@ Vue.createApp().component(ActivityIndicator.name, ActivityIndicator)
 
 <demo-wrapper
   src="src/packages/activity-indicator/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/activity-indicator/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 

--- a/src/packages/activity-indicator/README.md
+++ b/src/packages/activity-indicator/README.md
@@ -21,12 +21,7 @@ Vue.createApp().component(ActivityIndicator.name, ActivityIndicator)
 
 <demo-wrapper
   src="src/packages/activity-indicator/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/activity-indicator/demo/demo*.vue')
-</script>
 
 ### API
 

--- a/src/packages/agree/README.en-US.md
+++ b/src/packages/agree/README.en-US.md
@@ -21,12 +21,7 @@ Vue.createApp().component(Agree.name, Agree)
 
 <demo-wrapper
   src="src/packages/agree/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/agree/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 

--- a/src/packages/agree/README.md
+++ b/src/packages/agree/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(Agree.name, Agree)
 
 <demo-wrapper
   src="src/packages/agree/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/agree/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/amount/README.en-US.md
+++ b/src/packages/amount/README.en-US.md
@@ -25,12 +25,7 @@ The font `DINPro-Medium` is used in the component for the case show only, if nec
 
 <demo-wrapper
   src="src/packages/amount/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/amount/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 

--- a/src/packages/amount/README.md
+++ b/src/packages/amount/README.md
@@ -25,12 +25,7 @@ Vue.createApp().component(Amount.name, Amount)
 
 <demo-wrapper
   src="src/packages/amount/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/amount/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/bill/README.en-US.md
+++ b/src/packages/bill/README.en-US.md
@@ -18,7 +18,10 @@ Vue.createApp().component(Bill.name, Bill)
 ```
 
 ### 代码演示
-<!-- DEMO -->
+
+<demo-wrapper
+  src="src/packages/bill/demo"
+/>
 
 ### API
 

--- a/src/packages/bill/README.md
+++ b/src/packages/bill/README.md
@@ -21,12 +21,7 @@ Vue.createApp().component(Bill.name, Bill)
 
 <demo-wrapper
   src="src/packages/bill/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/bill/demo/demo*.vue')
-</script>
 
 ### API
 

--- a/src/packages/button/README.en-US.md
+++ b/src/packages/button/README.en-US.md
@@ -21,14 +21,7 @@ Vue.createApp().component(Button.name, Button)
 
 <demo-wrapper
   src="src/packages/button/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/button/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 

--- a/src/packages/button/README.md
+++ b/src/packages/button/README.md
@@ -21,12 +21,7 @@ Vue.createApp().component(Button.name, Button)
 
 <demo-wrapper
   src="src/packages/button/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/button/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/captcha/README.en-US.md
+++ b/src/packages/captcha/README.en-US.md
@@ -20,18 +20,12 @@ Vue.createApp().component(Captcha.name, Captcha)
 
 <demo-wrapper
   src="src/packages/captcha/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/captcha/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Captcha Props
+
 | Props | Description | Type | Default |
 |----|-----|------|------|
 | v-model | whether to show captcha or not | Boolean | `false` |
@@ -48,29 +42,34 @@ const demos = import.meta.globEager('../../../src/packages/captcha/demo/demo*.vu
 | count-normal-text |text of send verification code button |String| `发送验证码` |
 | count-active-text |text of send verification code button in countdown state|String| `{$1}秒后重发` |
 
-
-
 #### Captcha Methods
 
 #### countdown()
+
 Start the time counter
 
 ##### resetcount()
+
 Reset the time counter
 
 #### setError(message)
+
 Set and show error message
 
 #### Captcha Events
 
 ##### @show()
+
 Invoked when captcha is shown
 
 #### @hide()
+
 Invoked when captcha is hidden
 
 #### @send(countdown)
+
 Invoked when user clicks resend button. The first time you open or click the reissue button triggers and starts the countdown. If `auto-countdown` is false, you need to manually call `countdown`.
 
 #### @submit(code)
+
 Invoked when user submits

--- a/src/packages/captcha/README.md
+++ b/src/packages/captcha/README.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/captcha
 
 # Captcha 验证码
 
-
 验证码校验窗口
 
 ## 引入
@@ -21,16 +20,12 @@ Vue.createApp().component(Captcha.name, Captcha)
 
 <demo-wrapper
   src="src/packages/captcha/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/captcha/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Captcha Props
+
 |属性 | 说明 | 类型 | 默认值|
 |----|-----|------|------|
 |value|验证码窗口是否显示|Boolean|`false`|
@@ -50,24 +45,31 @@ const demos = import.meta.globEager('../../../src/packages/captcha/demo/demo*.vu
 ### Captcha Methods
 
 #### countdown()
+
 开始倒计时
 
 #### resetcount()
+
 重置倒计时
 
 #### setError(message)
+
 设置报错信息并显示
 
 ### Captcha Events
 
 #### @show()
+
 验证码组件显示事件
 
 #### @hide()
+
 验证码组件隐藏事件
 
 #### @send(countdown)
+
 发送验证码事件, 第一次打开时或点击重发按钮后触发并开始倒计时，如果`auto-countdown`为`false`需手动调用`countdown`开始倒计时
 
 #### @submit(code)
+
 用户提交输入内容事件

--- a/src/packages/cashier/README.en-US.md
+++ b/src/packages/cashier/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/cashier
 
 # Cashier
 
-
 Business payment pop-up window, supports payment channel selecting and payment verification code sending
 
 ### Import
@@ -21,25 +20,19 @@ Vue.createApp().component(Cashier.name, Cashier)
 
 <demo-wrapper
   src="src/packages/cashier/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Cashier Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model| display cashier or not|Boolean|`false`|-|
 |channels|data source of payment channel |Array<{text, value, icon, iconSvg, img, action}>|`[]`|`icon` can be used as the `name` attribute of `className` or component `Icon`, `iconSvg` for using svg icon, `img` is an icon link (choose one with `icon`), `action` is a special action handler|
 |channel-limit|show more payment channels button when the payment channels exceeds the limit|Number|`2`|-|
 |default-index|default selected index of payment channel |Number|`0`|-|
-|title|cashier title|String|`pay	`|-|
+|title|cashier title|String|`pay `|-|
 |large-radius <sup class="version-after">2.4.0+</sup>|large radius of title bar|Boolean|`false`|-|
 |payment-title|payment amount title|String|`支付金额(元)`|support `html fragment`|
 |payment-amount|payment amount|String|`0.00`|support `html fragment`|
@@ -48,10 +41,10 @@ const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vu
 |pay-button-disabled|disable payment button|Boolean|`false`|-|
 |more-button-text|more payment channels button text|String|`更多支付方式`|support `html fragment`|
 
-
 #### Cashier Methods
 
 ##### next(scene, option)
+
 To the next step of Cashier
 
 |Parameters | Description | Type | Default| Note|
@@ -88,7 +81,6 @@ To the next step of Cashier
 |handler| button clickback | Function | - | - |
 |actions| buttons group | Array<{buttonText, handler}> | - | used when there are two buttons |
 
-
 * `fail` option
 
 |Props | Description | Type | Default | Note|
@@ -101,6 +93,7 @@ To the next step of Cashier
 #### Captcha Slots
 
 ##### header
+
 Scoped slot of captcha header
 
 ```html
@@ -113,31 +106,41 @@ Scoped slot of captcha header
   ></md-notice-bar>
 </div>
 ```
+
 ##### header
+
 Scoped slot of captcha footer
 
 ##### channel
+
 Payment channel area slot, which can be used to add payment channel special operations, such as adding a bank card
 
 ##### payButton
+
 Payment button slot
 
 ##### scene
+
 Custom scene slot, open with `next('custom')`
 
 #### Cashier Events
 
 ##### @select(item: {text, value})
+
 Payment channel selected
 
 ##### @pay(item: {text, value})
+
 Confirm payment channels and initiate payment
 
 ##### @cancel()
+
 Cancel payment
 
 ##### @show()
+
 Display cashier
 
 ##### @hide()
+
 Hide cashier

--- a/src/packages/cashier/README.md
+++ b/src/packages/cashier/README.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/cashier
 
 # Cashier 收银台
 
-
 业务支付弹窗，支持支付渠道选择和支付验证码发送
 
 ## 引入
@@ -21,16 +20,12 @@ Vue.createApp().component(Cashier.name, Cashier)
 
 <demo-wrapper
   src="src/packages/cashier/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Cashier Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |v-model|收银台是否显示|Boolean|`false`| |
@@ -46,6 +41,7 @@ const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vu
 |more-button-text|更多支付渠道按钮文案|String|`更多支付方式`|支持`html fragment`|
 
 #### CashierChannel
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |text|渠道展示名称|String|||
@@ -58,9 +54,11 @@ const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vu
 ### Cashier Methods
 
 #### setChannels(channels: CashierChannel)
+
 手动设置支付渠道数据源
 
 #### next(scene, option?)
+
 进入收银台下一步
 
 |参数 | 说明 | 类型 | 默认值| 备注|
@@ -109,6 +107,7 @@ const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vu
 ### Captcha Slots
 
 #### header
+
 头部内容scoped插槽
 
 ```html
@@ -123,30 +122,39 @@ const demos = import.meta.globEager('../../../src/packages/cashier/demo/demo*.vu
 ```
 
 #### footer
+
 底部内容scoped插槽
 
 #### channel
+
 支付渠道区域插槽，可用于添加支付渠道特殊操作，如添加银行卡
 
 #### payButton
+
 发起支付插槽
 
 #### scene
+
 自定义场景插槽，使用`next('custom')`打开
 
 ### Cashier Events
 
 #### @select(item: {text, value})
+
 支付渠道选中事件
 
 #### @pay(item: {text, value})
+
 支付渠道确认并发起支付事件
 
 #### @cancel()
+
 取消支付事件
 
 #### @show()
+
 收银台弹窗展示事件
 
 #### @hide()
+
 收银台弹窗隐藏事件

--- a/src/packages/cell-item/README.en-US.md
+++ b/src/packages/cell-item/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/cell-item
 
 # CellItem
 
-
 Arrange vertically and display current contents, status and other allowable operations.
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(CellItem.name, CellItem)
 
 <demo-wrapper
   src="src/packages/cell-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/cell-item/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### CellItem Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |title|title|String|-|-|
@@ -43,19 +36,25 @@ const demos = import.meta.globEager('../../../src/packages/cell-item/demo/demo*.
 |no-border|remove border|Boolean|`false`|-|
 
 #### CellItem Events
+
 ##### @click(event)
+
 click event when not disabled
 
 #### CellItem Slots
 
 ##### default
+
 default content slot
 
 ##### left
+
 left content slot
 
 ##### right
+
 right content slot
 
 ##### children
+
 extra children slot

--- a/src/packages/cell-item/README.md
+++ b/src/packages/cell-item/README.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/cell-item
 
 # CellItem 单元格
 
-
 列表用于展现并列层级的信息内容，列表可承载功能入口、功能操作、信息展示等功能。
 
 ## 引入
@@ -21,16 +20,12 @@ Vue.createApp().component(CellItem.name, CellItem)
 
 <demo-wrapper
   src="src/packages/cell-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/cell-item/demo/demo*.vue')
-</script>
 
 ## API
 
 ### CellItem Props
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 |title|标题|String| | |
@@ -41,19 +36,25 @@ const demos = import.meta.globEager('../../../src/packages/cell-item/demo/demo*.
 |no-border|去除边框|Boolean|`false`| |
 
 ### CellItem Events
+
 #### @click(event)
+
 非禁用状态下的点击事件
 
 ### CellItem Slots
 
 #### default
+
 内容默认插槽
 
 #### left
+
 起始区域插槽
 
 #### right
+
 末尾附加内容插槽
 
 #### children
+
 额外内容插槽

--- a/src/packages/check/README.en-US.md
+++ b/src/packages/check/README.en-US.md
@@ -24,12 +24,10 @@ Vue.createApp().component(CheckList.name, CheckList)
 
 <demo-wrapper
   src="src/packages/check/demo"
-  :demos="demos"
+  
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue')
-</script>
+
 
 <!-- DEMO -->
 

--- a/src/packages/check/README.md
+++ b/src/packages/check/README.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/check
 
 # Check 复选项
 
-
 ## 引入
 
 ```javascript
@@ -22,16 +21,15 @@ Vue.createApp().component(CheckList.name, CheckList)
 
 <demo-wrapper
   src="src/packages/check/demo"
-  :demos="demos"
+  
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue')
-</script>
+
 
 ## API
 
 ### Check Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |name|唯一键值|any|`true`|当选中时，双向绑定的值|
@@ -47,6 +45,7 @@ const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue'
 ---
 
 ### CheckBox Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |name|唯一键值|any|`true`|当选中时，双向绑定的值|
@@ -56,6 +55,7 @@ const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue'
 ---
 
 ### CheckGroup Props
+
 复选组，用以选中多个复选项。与`Check`或`CheckBox`组合使用。
 
 |属性 | 说明 | 类型 | 默认值 | 备注 |
@@ -84,6 +84,7 @@ const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue'
 |name|需要反选的键值|String|-|
 
 #### toggleAll(checked?: Boolean)
+
 全选或者反选（对`disabled`的选项不改变其原选中状态）
 
 |参数 | 说明 | 类型 | 默认值 |
@@ -93,6 +94,7 @@ const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue'
 ---
 
 ### CheckList Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |value|选中项的`value`|Array|-|-|
@@ -106,6 +108,7 @@ const demos = import.meta.globEager('../../../src/packages/check/demo/demo*.vue'
 |is-slot-scope|是否强制使用或不使用`slot-scope`|Boolean|-|某些情况下需要根据业务逻辑动态确定是否使用，可避免直接组件上加`if/else`|
 
 ### CheckList Slots
+
 ```html
 <template>
   <md-check-list :options="data">

--- a/src/packages/codebox/README.en-US.md
+++ b/src/packages/codebox/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/codebox
 
 # Codebox
 
-
 ### Import
 
 ```javascript
@@ -19,18 +18,12 @@ Vue.createApp().component(Codebox.name, Codebox)
 
 <demo-wrapper
   src="src/packages/codebox/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/codebox/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Codebox Props
+
 | Props | Description | Type | Default |
 |----|-----|------|------|
 | v-model | captcha | String | - |
@@ -50,9 +43,11 @@ const demos = import.meta.globEager('../../../src/packages/codebox/demo/demo*.vu
 ##### focus()
 
 ##### blur()
+
 Hide keyboard
 
 #### Codebox Events
 
 ##### @submit(code)
+
 Invoked when user submit

--- a/src/packages/codebox/README.md
+++ b/src/packages/codebox/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Codebox.name, Codebox)
 
 <demo-wrapper
   src="src/packages/codebox/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/codebox/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Codebox Props
+
 |属性 | 说明 | 类型 | 默认值|
 |----|-----|------|------|
 |value|验证码字符串|String| |
@@ -47,12 +43,15 @@ const demos = import.meta.globEager('../../../src/packages/codebox/demo/demo*.vu
 ### Codebox Methods
 
 #### focus()
+
 聚焦输入
 
 #### blur()
+
 失焦隐藏键盘
 
 ### Codebox Events
 
 #### @submit(code)
+
 用户提交输入内容事件

--- a/src/packages/date-picker/README.en-US.md
+++ b/src/packages/date-picker/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/date-picker
 
 # DatePicker
 
-
 Date or time selecting, supports year/month/day/hour/minute/second custom selecting
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(DatePicker.name, DatePicker)
 
 <demo-wrapper
   src="src/packages/date-picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### DatePicker Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |v-model:visible|display date picker or not|Boolean|`false`|-|
@@ -42,21 +35,22 @@ const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo
 |min-date|selectable min date(time)|Date|-|-|
 |max-date|selectable max date(time)|Date|-|-|
 |unit-text|element unit for text displaying|Array|`['Year', 'Month', 'Day', 'Hour', 'Minute', 'Second']`|`text-render` for complex logic|
-|text-render|customized option for text displaying|Function(typeFormat, column0Value, column1Value, ...): String|-|`unit-text` is invalid when using `text-render`, refer to `Appendix`|              
-|today-text|displaying text of today|String|`today`|use `&` to take placeholder date, like `&(today)`| 
-|line-height|line height of options|Number|`45`|unit `px`| 
-|keep-index|keep last stop position when the column data changes|Boolean|`false`|-|          
-|is-view|inline-display in page, otherwise it shows as `Popup`|Boolean|`false`|-| 
+|text-render|customized option for text displaying|Function(typeFormat, column0Value, column1Value, ...): String|-|`unit-text` is invalid when using `text-render`, refer to `Appendix`|
+|today-text|displaying text of today|String|`today`|use `&` to take placeholder date, like `&(today)`|
+|line-height|line height of options|Number|`45`|unit `px`|
+|keep-index|keep last stop position when the column data changes|Boolean|`false`|-|
+|is-view|inline-display in page, otherwise it shows as `Popup`|Boolean|`false`|-|
 |title|title of date-picker|String|-|-|
 |describe|description of date-picker|String|-|-|
-|ok-text|confirmation text|String|`confirm`|-| 
-|cancel-text|cancellation text|String|`cancel`|-| 
+|ok-text|confirmation text|String|`confirm`|-|
+|cancel-text|cancellation text|String|`cancel`|-|
 |large-radius|large radius of title bar|Boolean|`false`|-|
 |mask-closable|picker will be closed when clicking mask|String|`true`|-|
 
 #### DatePicker Methods
 
 ##### getColumnValues(): columnsValue
+
 Get all values of currently seleted items
 
 Returns
@@ -65,10 +59,10 @@ Returns
 |----|-----|------|
 |columnsValue|values of all selected items in the column|Array<{value, text, ...}>|
 
-
 #### DatePicker Events
 
 ##### @change(columnIndex, itemIndex, value)
+
 Change selections of date picker
 
 |Parameters | Description | Type|
@@ -78,17 +72,20 @@ Change selections of date picker
 |value|change the value of selected item|Object: {value, text, ...}|
 
 ##### @confirm()
+
 Confirm the selection of date picker(only when `is-view` is `false`）
 
 ##### @cancel()
+
 Cancel date picker's selection (only when `is-view` is `false`）
 
 ##### @show()
+
 Show date picker (only when `is-view` is `false`）
 
 ##### @hide()
-Hide date picker (only when `is-view` is `false`）
 
+Hide date picker (only when `is-view` is `false`）
 
 #### Appendix
 

--- a/src/packages/date-picker/README.md
+++ b/src/packages/date-picker/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(DatePicker.name, DatePicker)
 
 <demo-wrapper
   src="src/packages/date-picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo*.vue')
-</script>
 
 ## API
 
 ### DatePicker Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |v-model:visible|日期选择器是否可见|Boolean|`false`|-|
@@ -40,20 +36,21 @@ const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo
 |max-date|最大可选日期（时间）|Date|-|-|
 |unit-text|元素单位展示文案设置|Array|`['年', '月', '日', '时', '分', '秒']`|复杂逻辑使用`text-render`|
 |text-render|自定义选项展示文案方法|Function(typeFormat, column0Value, column1Value, ...): String|-|如果使用`text-render`则`unit-text`无效, 示例见附录|
-|today-text|今天展示文案设置|String|`今天`|使用`&`可占位日期数字，如`&(今天)`| 
+|today-text|今天展示文案设置|String|`今天`|使用`&`可占位日期数字，如`&(今天)`|
 |line-height|选择器选项行高|Number|`45`|单位`px`|  
-|keep-index|当列数据变化时保持上次停留的位置|Boolean|`false`|-|        
-|is-view|是否内嵌在页面内展示, 否则以弹层形式|Boolean|`false`|-| 
+|keep-index|当列数据变化时保持上次停留的位置|Boolean|`false`|-|
+|is-view|是否内嵌在页面内展示, 否则以弹层形式|Boolean|`false`|-|
 |title|选择器标题|String|-|-|
 |describe|选择器描述|String|-|-|
-|ok-text|选择器确认文案|String|`确认`|-| 
-|cancel-text|选择器取消文案|String|`取消`|-| 
+|ok-text|选择器确认文案|String|`确认`|-|
+|cancel-text|选择器取消文案|String|`取消`|-|
 |large-radius|选择器标题栏大圆角模式|Boolean|`false`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 
 ### DatePicker Methods
 
 #### getColumnValues(): columnsValue
+
 获取所有列选中项的值
 
 返回
@@ -65,6 +62,7 @@ const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo
 ### DatePicker Events
 
 #### @change(columnIndex, itemIndex, value)
+
 选择器选中项更改事件
 
 |参数 | 说明 | 类型 |
@@ -74,8 +72,8 @@ const demos = import.meta.globEager('../../../src/packages/date-picker/demo/demo
 |value|更改列选中项的的值|Object: {text, value, typeFormat}|
 
 #### @confirm()
-选择器确认选择事件（仅`is-view`为`false`）
 
+选择器确认选择事件（仅`is-view`为`false`）
 
 ### 附录
 

--- a/src/packages/detail-item/README.en-US.md
+++ b/src/packages/detail-item/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/detail-item
 
 # DetailItem
 
-
 Detail list usually used as bill details, inventory details and so on.
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(DetailItem.name, DetailItem)
 
 <demo-wrapper
   src="src/packages/detail-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/detail-item/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### CellItem Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |title|title|String|-|-|

--- a/src/packages/detail-item/README.md
+++ b/src/packages/detail-item/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(DetailItem.name, DetailItem)
 
 <demo-wrapper
   src="src/packages/detail-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/detail-item/demo/demo*.vue')
-</script>
 
 ## API
 
 ### DetailItem Props
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 |title|标题|String| | |

--- a/src/packages/dialog/README.en-US.md
+++ b/src/packages/dialog/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/dialog
 
 # Dialog
 
-
 A floating layer to get users' feedback or display information.
 
 ### Import
@@ -23,18 +22,12 @@ this.$dialog.alert({ content: '' }) // Totally Import
 
 <demo-wrapper
   src="src/packages/dialog/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/dialog/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Dialog Props
+
 | Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 | v-model | whether to show a dialog or not | Boolean | `false` | - |
@@ -77,17 +70,21 @@ Header slot, generally used for placing pictures, etc <sup class="version-after"
 #### Dialog Instance Methods
 
 ##### close()
+
 Hide dialog
 
 #### Dialog Instance Events
 
 ##### @show()
+
 Invoked after dialog is shown
 
 ##### @hide()
+
 Invoked after dialog is hidden
 
 ##### @click(btn, index)
+
 Invoked after some button is clicked
 
 |Props | Description | Type |
@@ -95,11 +92,12 @@ Invoked after some button is clicked
 |btn|object corresponding to the clicked button in the btns list|Object: DialogBtnOptions|
 |index|index of object corresponding to the clicked button in the btns list|Number|
 
-
 #### Dialog Static Methods
+
 Dynamically create interactive dialogs
 
 ##### Dialog.confirm(props)
+
 Dynamically create a confirmation dialog
 
 | Props | Description | Type | Default |
@@ -117,6 +115,7 @@ Dynamically create a confirmation dialog
 | onHide <sup class="version-after">2.5.0+</sup>| callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.alert(props)
+
 Dynamically create an alert dialog
 
 | Props | Description | Type | Default |
@@ -131,6 +130,7 @@ Dynamically create an alert dialog
 | onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.succeed(props)
+
 Dynamically create a success dialog
 
 | Props | Description | Type | Default |
@@ -144,6 +144,7 @@ Dynamically create a success dialog
 | onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.failed(props)
+
 Dynamically create a fail dialog
 
 | Props | Description | Type | Default |
@@ -157,4 +158,5 @@ Dynamically create a fail dialog
 | onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.closeAll()
+
 Close all global dialogs

--- a/src/packages/dialog/README.md
+++ b/src/packages/dialog/README.md
@@ -22,12 +22,7 @@ this.$dialog.alert({ content: '' }) // 全量引入
 
 <demo-wrapper
   src="src/packages/dialog/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/dialog/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/drop-menu/README.en-US.md
+++ b/src/packages/drop-menu/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/drop-menu
 
 # DropMenu
 
-
 Drop-down menu is for list filtering
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(DropMenu.name, DropMenu)
 
 <demo-wrapper
   src="src/packages/drop-menu/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### DropMenu Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |data|data source|Array<{text, disabled, options, ...}>|`[]`|`disabled` is whether to disable a button or not; the type of `options` is `Array<{text, disabled, ...}>`|
@@ -42,6 +35,7 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 #### DropMenu Methods
 
 ##### getSelectedValue(index): listItem
+
 Get selected value of a `barItem`
 
 |Parameters | Description | Type| Default|
@@ -55,6 +49,7 @@ Returns
 |listItem|data of `listItem`|Object: {text, disabled, options, ...}|
 
 ##### getSelectedValues(): listItems
+
 Get selected values of all `barItem`
 
 Returns
@@ -66,6 +61,7 @@ Returns
 #### DropMenu Events
 
 ##### @change(barItem, listItem)
+
 Select some event
 
 |Props | Description | Type|
@@ -74,7 +70,9 @@ Select some event
 |listItem|data of `listItem`|Object: {text, disabled, ...}|
 
 ##### @show()
+
 Show events on drop-down menu
 
 ##### @hide()
+
 Hide events on drop-down menu

--- a/src/packages/drop-menu/README.md
+++ b/src/packages/drop-menu/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(DropMenu.name, DropMenu)
 
 <demo-wrapper
   src="src/packages/drop-menu/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.vue')
-</script>
 
 <style>
   .demo-wrapper .md-drop-menu {
@@ -41,6 +36,7 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 ## API
 
 ### DropMenu Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |data|数据源|Array\<[DropMenuBarItem](#dropmenubaritem)\>|`[]`||
@@ -64,10 +60,10 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 |disabled|禁用|Boolean|`false`||
 |[property]|其它数据|any|||
 
-
 ### DropMenu Methods
 
 #### getSelectedValue(index)
+
 获取某菜单项选中值
 
 |参数 | 说明 | 类型 | 默认值|
@@ -81,6 +77,7 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 |listItem|选项数据|Object: [DropMenuListItem](#dropmenulistitem)|
 
 #### getSelectedValues()
+
 获取所有菜单项选中值
 
 返回
@@ -92,6 +89,7 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 ### DropMenu Events
 
 #### @change(barItem, listItem)
+
 选中某项事件
 
 |属性 | 说明 | 类型|
@@ -100,7 +98,9 @@ const demos = import.meta.globEager('../../../src/packages/drop-menu/demo/demo*.
 |listItem|选项数据|Object: [DropMenuListItem](#dropmenulistitem)|
 
 #### @show()
+
 下拉菜单展示事件
 
 #### @hide()
+
 下拉菜单隐藏事件

--- a/src/packages/field/README.en-US.md
+++ b/src/packages/field/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/field
 
 # Field
 
-
 Arrange vertically and display current contents, status and other allowable operations.
 
 ### Import
@@ -22,24 +21,18 @@ Vue.createApp().component(FieldItem.name, FieldItem)
 
 <demo-wrapper
   src="src/packages/field/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/field/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Field Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |title|title|String|-|-|
 |brief|description|String|-|-|
 |disabled|disable content operation|Boolean|`false`|-|
-|solid|	the width of title is fixed or not|Boolean|`false`|-|
+|solid| the width of title is fixed or not|Boolean|`false`|-|
 |plain|plain style|Boolean|`false`|-|
 
 When use `disabled` prop, its descendants can use [inject](https://vuejs.org/v2/api/#provide-inject)to have access of `Field` ancestor.
@@ -66,20 +59,25 @@ export default {
 #### Field Slots
 
 ##### default
+
 default content slot
 
 ##### header
+
 header content slot
 
 ##### action
+
 header action slot
 
 ##### footer
+
 footer content slot
 
 ---
 
 #### FieldItem Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |title|title|String|-|-|
@@ -89,19 +87,25 @@ footer content slot
 |arrow|arrow indicator|Boolean|false|-|
 
 #### FieldItem Events
+
 ##### @click(event)
+
 click event when not disabled
 
 #### FieldItem Slots
 
 ##### default
+
 default content slot
 
 ##### left
+
 left content slot
 
 ##### right
+
 right content slot
 
 ##### children
+
 extra children slot

--- a/src/packages/field/README.md
+++ b/src/packages/field/README.md
@@ -21,16 +21,12 @@ Vue.createApp().component(FieldItem.name, FieldItem)
 
 <demo-wrapper
   src="src/packages/field/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/field/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Field Props
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 |title|标题|String|-|-|
@@ -64,20 +60,25 @@ export default {
 ### Field Slots
 
 #### default
+
 内容默认插槽
 
 #### header
+
 页眉内容插槽
 
 #### action
+
 页眉操作区域插槽
 
 #### footer
+
 页脚内容插槽
 
 ---
 
 ### FieldItem Props
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 |title|标题|String|-|-|
@@ -88,19 +89,25 @@ export default {
 |arrow|动作箭头标识|Boolean|false|-|
 
 ### FieldItem Events
+
 #### @click(event)
+
 非禁用状态下的点击事件
 
 ### FieldItem Slots
 
 #### default
+
 内容默认插槽
 
 #### left
+
 起始区域插槽
 
 #### right
+
 末尾区域插槽
 
 #### children
+
 额外内容插槽

--- a/src/packages/icon/README.en-US.md
+++ b/src/packages/icon/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/icon
 
 # Icon
 
-
 IconFont、SVG Icons
 
 ### Import
@@ -25,18 +24,12 @@ Custom svg icons and import local font file, please refer to <a href="javascript
 
 <demo-wrapper
   src="src/packages/icon/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/icon/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Icon Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |name|icon name|String|-|-|
@@ -76,6 +69,7 @@ module.exports = {
   }
 }
 ```
+
 3. Import Icons
 
 ```vue
@@ -113,7 +107,7 @@ export default {
   font-weight: 400;
   src: url(~mand-mobile/components/icon/iconfont.woff) format("woff"),url(~mand-mobile/components/icon/iconfont.woff) format("truetype")
 }
-``` 
+```
 
 * Reset stylus variable when customizing theme
 

--- a/src/packages/icon/README.md
+++ b/src/packages/icon/README.md
@@ -24,12 +24,7 @@ Vue.createApp().component(Icon.name, Icon)
 
 <demo-wrapper
   src="src/packages/icon/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/icon/demo/demo*.vue')
-</script>
 
 <style>
   .md-example-child-icon {
@@ -56,6 +51,7 @@ const demos = import.meta.globEager('../../../src/packages/icon/demo/demo*.vue')
 ## API
 
 #### Icon Props
+
 |属性 | 说明 | 类型 | 默认值| 备注|
 |----|-----|------|------|------|
 |name|图标名称|String| | |
@@ -66,7 +62,6 @@ const demos = import.meta.globEager('../../../src/packages/icon/demo/demo*.vue')
 ## 附录
 
 ### 自定义svg图标
-
 
 自定义svg图标需使用<a href="https://github.com/kisenka/svg-sprite-loader" target="_blank">svg-sprite-loader</a>，svg文件名即图标名称
 
@@ -96,6 +91,7 @@ module.exports = {
   }
 }
 ```
+
 3. 引入图标
 
 ```vue
@@ -123,7 +119,7 @@ export default {
 
 ### 引入本地字体文件
 
-> 注意：webpack配置[url-loader](https://github.com/webpack-contrib/url-loader)需要包含mand-mobile 
+> 注意：webpack配置[url-loader](https://github.com/webpack-contrib/url-loader)需要包含mand-mobile
 
 * 重置css中的图标字体  
 
@@ -134,7 +130,7 @@ export default {
   font-weight: 400;
   src: url(~mand-mobile/components/icon/iconfont.woff) format("woff"),url(~mand-mobile/components/icon/iconfont.woff) format("truetype")
 }
-``` 
+```
 
 * 自定义主题时重置stylus变量
 

--- a/src/packages/image-reader/README.en-US.md
+++ b/src/packages/image-reader/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/image-reader
 
 # ImageReader
 
-
 For photo album reading or photos taking
 
 ### Import
@@ -24,18 +23,12 @@ Vue.createApp().component(ImageReader.name, ImageReader)
 
 <demo-wrapper
   src="src/packages/image-reader/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/image-reader/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### ImageReader Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |name|identifier|String|-|used to distinguish multiple readers|
@@ -48,6 +41,7 @@ const demos = import.meta.globEager('../../../src/packages/image-reader/demo/dem
 #### ImageReader Events
 
 ##### @select(name, { files })
+
 Picture selection completed, while reading hasn't been started yet，only support web
 
 |Parameters | Description | Type| Note|
@@ -56,6 +50,7 @@ Picture selection completed, while reading hasn't been started yet，only suppor
 |files|image file objects set|Array\<File\>|-|
 
 ##### @complete(name, { dataUrl, blob, file })
+
 Picture reading completed
 
 |Parameters | Description | Type| Note|
@@ -66,6 +61,7 @@ Picture reading completed
 |file|image file object|File|-|
 
 ##### @error(name, { code, msg })
+
 Picture selection and reading failed
 
 |Parameters | Description | Type| Note|
@@ -102,6 +98,7 @@ imageProcessor(options[, fn])
 |quality|picture quality|Number|value range `0-1`|
 
 ### Appendix
+
 Picture read failed error code and error message
 
 ```

--- a/src/packages/image-reader/README.md
+++ b/src/packages/image-reader/README.md
@@ -20,16 +20,13 @@ Vue.createApp().component(ImageReader.name, ImageReader)
 
 <demo-wrapper
   src="src/packages/image-reader/demo"
-  :demos="demos"
+  
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/image-reader/demo/demo*.vue')
-</script>
 
 ## API
 
 ### ImageReader Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |name|标识|String| |可用于区分多个选择器|
@@ -42,6 +39,7 @@ const demos = import.meta.globEager('../../../src/packages/image-reader/demo/dem
 ### ImageReader Events
 
 #### @select(name, { files })
+
 图片选择完成事件，还未开始读取
 
 |属性 | 说明 | 类型| 备注|
@@ -50,6 +48,7 @@ const demos = import.meta.globEager('../../../src/packages/image-reader/demo/dem
 |files|图片对象集合|Array\<File\>|-|
 
 #### @complete(name, { dataUrl, blob, file })
+
 图片选择读取完成事件
 
 |属性 | 说明 | 类型| 备注|
@@ -60,6 +59,7 @@ const demos = import.meta.globEager('../../../src/packages/image-reader/demo/dem
 |blob |图片Blob对象，可用于`formData`|Blob|-|
 
 #### @error(name, { code, msg })
+
 图片选择读取失败事件
 
 |属性 | 说明 | 类型| 备注|
@@ -69,7 +69,6 @@ const demos = import.meta.globEager('../../../src/packages/image-reader/demo/dem
 |msg|错误信息，见附录|String|-|
 
 ## imageProcessor
-
 
 用于图片轴向修正，图片质量压缩，宽高控制
 
@@ -96,6 +95,7 @@ imageProcessor(options[, fn])
 |quality|图片质量|Number|取值范围`0-1`|
 
 ## 附录
+
 图片读取失败错误码和错误信息
 
 ```

--- a/src/packages/image-viewer/README.en-US.md
+++ b/src/packages/image-viewer/README.en-US.md
@@ -6,8 +6,7 @@ preview: https://didi.github.io/mand-mobile/examples/#/image-viewer
 
 # ImageViewer
 
-
-For	 browsing multiple pictures and swiping to switch pictures
+For  browsing multiple pictures and swiping to switch pictures
 
 ### Import
 
@@ -17,27 +16,19 @@ import { ImageViewer } from  'mand-mobile-next'
 Vue.createApp().component(ImageViewer.name, ImageViewer)
 ```
 
-
 ### Code Examples
 
 <demo-wrapper
   src="src/packages/image-viewer/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/image-viewer/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### ImageViewer Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 | v-model | viewer display | Boolean | `false` |
 | list |show picture list | Array\<String\> | `[]` | -|
 | initial-index | initialize the index of displayed image | Number | `0` | - |
 | has-dots | display the index of picture| Boolean | `true` | - |
-

--- a/src/packages/image-viewer/README.md
+++ b/src/packages/image-viewer/README.md
@@ -20,20 +20,15 @@ Vue.createApp().component(ImageViewer.name, ImageViewer)
 
 <demo-wrapper
   src="src/packages/image-viewer/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/image-viewer/demo/demo*.vue')
-</script>
 
 ### API
 
 #### ImageViewer Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 | v-model | 是否显示查看器 | Boolean | `false` |
 | list |展示图片列表 | Array\<String\> | `[]` | -|
 | initial-index | 初始索引值 | Number | `0` | - |
 | has-dots | 是否展示图片索引值 | Boolean | `true` | - |
-

--- a/src/packages/input-item/README.en-US.md
+++ b/src/packages/input-item/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/input-item
 
 # InputItem
 
-
 Single-line text input, supports text formatting in exact scenarios
 
 ### Import
@@ -25,22 +24,16 @@ Vue.createApp().component(InputItem.name, InputItem)
 
 <demo-wrapper
   src="src/packages/input-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/input-item/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### InputItem Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |type|input type, special type has text formatting|String|`text`|`text`,`bankCard`,`phone`,<br/>`money`,`password`|
-|preview-type <sup class="version-after">2.5.0+</sup>|input preview type|String|-|generally used for initial input value (such as masked *ID number with mobile phone number, mobile phone number*) preview and the first time you trigger an edit operation, such as clicking the backspace key and other character key clicks, ** the pre-fill value will be cleared first and the input will be switched to `type` **|
+|preview-type <sup class="version-after">2.5.0+</sup>|input preview type|String|-|generally used for initial input value (such as masked *ID number with mobile phone number, mobile phone number*) preview and the first time you trigger an edit operation, such as clicking the backspace key and other character key clicks, **the pre-fill value will be cleared first and the input will be switched to `type`**|
 |name|name of input|String|-|one of the event arguments, is used to distinguish multi inputs|
 |v-model|value of input|String|-|-|
 |title|title of input|String|-|`slot left` as alternative|
@@ -67,46 +60,59 @@ const demos = import.meta.globEager('../../../src/packages/input-item/demo/demo*
 #### InputItem Slots
 
 #### left
+
 Left slot, generally is used to place icons, etc.
 
 #### right
+
 Right slot, generally is used to place icons, etc.
 
 #### brief
+
 Description slot，generally used to description is more complicated, can not be satisfied with `brief` in `Props`, need to use `v-if` control.(Not recommended)
 
 #### error
+
 Error slot，generally used to error is more complicated, can not be satisfied with `error` in `Props`, need to use `v-if` control, refer to the 'input with error message' in the example.(Not recommended)
 
 #### InputItem Methods
 
 ##### focus()
+
 Input gets focus
 
 ##### blur()
+
 Input loses focus
 
 ##### getValue()
+
 Get value of input
 
 #### InputItem Events
 
 ##### @focus(name)
+
 Input gets focus
 
 ##### @blur(name)
+
 Input loses focus
 
 ##### @change(name, value)
+
 Change the value of input
 
 ##### @confirm(name, value)
+
 Input value confirmation, valid only when using a financial numeric keypad or component within a `form` element
 
 ##### @keyup(name, event)
+
 key press, is invoked only if `is-virtual-keyboard` is false
 
 ##### @keydown(name, event)
+
 key release, is invoked only if `is-virtual-keyboard` is false
 
 ### Validation WIP

--- a/src/packages/input-item/README.md
+++ b/src/packages/input-item/README.md
@@ -26,16 +26,12 @@ Vue.createApp().component(InputItem.name, InputItem)
 
 <demo-wrapper
   src="src/packages/input-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/input-item/demo/demo*.vue')
-</script>
 
 ## API
 
 ### InputItem Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |type|表单类型，特殊类型自带文本格式化|String|`text`|`text(文本)`,`bankCard(银行卡号)`,`phone(手机号)`,<br/>`money(金额)`,`digit(数字)`,`password(密码)`,<br/>以及其他的标准`Html Input`类型|
@@ -66,50 +62,59 @@ const demos = import.meta.globEager('../../../src/packages/input-item/demo/demo*
 ### InputItem Slots
 
 ### left
+
 左侧插槽，一般用于放置图标等
 
 ### right
+
 右侧插槽，一般用于放置图标等
 
 ### brief
 
-
 表单描述插槽，一般用于描述内容较复杂，用`Props`中`brief`无法满足的情况，需用`v-if`控制（不推荐）
 
 ### error
-
 
 表单错误插槽，一般用于错误内容较复杂，用`Props`中`error`无法满足的情况，需用`v-if`控制，参考示例中的`错误提示`（不推荐）
 
 ### InputItem Methods
 
 #### focus()
+
 表单获得焦点
 
 #### blur()
+
 表单失去焦点
 
 #### getValue()
+
 获取表单值
 
 ### InputItem Events
 
 #### @focus(name)
+
 表单获得焦点事件
 
 #### @blur(name)
+
 表单失去焦点事件
 
 #### @change(name, value)
+
 表单值变化事件
 
 #### @confirm(name, value)
+
 表单值确认事件， 仅使用金融数字键盘或组件在`form`元素内时有效
 
 #### @keyup(name, event)
+
 表单按键按下事件，仅`is-virtual-keyboard`为`false`时触发
 
 #### @keydown(name, event)
+
 表单按键释放事件，仅`is-virtual-keyboard`为`false`时触发
 
 ## 表单校验 WIP

--- a/src/packages/landscape/README.en-US.md
+++ b/src/packages/landscape/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/landscape
 
 # Landscape
 
-
 To display ads or descriptions in a floating layer
 
 ### Import
@@ -21,18 +20,14 @@ Vue.createApp().component(Landscape.name, Landscape)
 
 <demo-wrapper
   src="src/packages/landscape/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/landscape/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 
 ### API
 
 #### Landscape Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|----- |
 |v-model|display popup layer or not|Boolean|`false`| - |
@@ -40,10 +35,13 @@ const demos = import.meta.globEager('../../../src/packages/landscape/demo/demo*.
 |mask-closable|if popup layer can be closed through clicking on the mask|Boolean|`false`| - |
 |full-screen|whether display as full screen|Boolean|`false`| - |
 | transition | the animation effect of dialog | String | when `full-screen` is `true`, the default value is `md-fade`;otherwise the default value is `md-punch` |refer to [Transition](https://didi.github.io/mand-mobile/#/en-US/docs/components/feedback/transition?anchor=API) for optional values |
+
 #### Landscape Events
 
 ##### @show()
+
 Display popup
 
 ##### @hide()
+
 Hide popup

--- a/src/packages/landscape/README.md
+++ b/src/packages/landscape/README.md
@@ -20,12 +20,10 @@ Vue.createApp().component(Landscape.name, Landscape)
 
 <demo-wrapper
   src="src/packages/landscape/demo"
-  :demos="demos"
+  
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/landscape/demo/demo*.vue')
-</script>
+
 
 ## API
 

--- a/src/packages/notice-bar/README.en-US.md
+++ b/src/packages/notice-bar/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/notice-bar
 
 # NoticeBar
 
-
 Mostly for system alerts, event reminders, etc
 
 ### Import
@@ -17,23 +16,16 @@ import { NoticeBar } from  'mand-mobile-next'
 Vue.createApp().component(NoticeBar.name, NoticeBar)
 ```
 
-
 ### Code Examples
 
 <demo-wrapper
   src="src/packages/notice-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/notice-bar/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### NoticeBar Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |mode|notice bar mode|String|-|`closable`, `link`|
@@ -48,15 +40,19 @@ const demos = import.meta.globEager('../../../src/packages/notice-bar/demo/demo*
 #### NoticeBar Slots
 
 #### default
+
 Default slot of content
 
 #### left
+
 Left slot, generally is used to place icons, etc
 
 #### right
+
 Right slot, generally is used to place icons, etc
 
 #### NoticeBar Events
 
 ##### @close()
+
 Notice bar close event (set `mode` to 'closable' or `closable` to true)

--- a/src/packages/notice-bar/README.md
+++ b/src/packages/notice-bar/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(NoticeBar.name, NoticeBar)
 
 <demo-wrapper
   src="src/packages/notice-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/notice-bar/demo/demo*.vue')
-</script>
 
 ## API
 
 ### NoticeBar Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |mode|右边提示类型|String| |`closable`, `link`|
@@ -44,16 +40,19 @@ const demos = import.meta.globEager('../../../src/packages/notice-bar/demo/demo*
 ### NoticeBar Slots
 
 #### default
+
 默认内容插槽
 
 #### left
+
 左侧插槽，一般用于放置图标等
 
 #### right
+
 右侧插槽，一般用于放置图标等
 
 ### NoticeBar Events
 
 #### @close()
-通告栏关闭事件（设置`mode`为`closable`）
 
+通告栏关闭事件（设置`mode`为`closable`）

--- a/src/packages/number-keyboard/README.en-US.md
+++ b/src/packages/number-keyboard/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/number-keyboard
 
 # NumberKeyboard
 
-
 Generally used for financial scenarios such as password, verification code or payment amount input
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(NumberKeyboard.name, NumberKeyboard)
 
 <demo-wrapper
   src="src/packages/number-keyboard/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/number-keyboard/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### NumberKeyboard Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |v-model|display keyboard or not|Boolean|`false`|-|
@@ -52,17 +45,21 @@ const demos = import.meta.globEager('../../../src/packages/number-keyboard/demo/
   <md-icon name="security"></md-icon>&nbsp;安全支付
 </md-number-keyboard>
 ```
+
 #### NumberKeyboard Methods
 
 ##### show()
+
 Display keyboard
 
 ##### hide()
+
 Hide keyboard
 
 #### NumberKeyboard Events
 
 ##### @enter(val)
+
 Click numeric key
 
 |Props | Description | Type|
@@ -70,7 +67,9 @@ Click numeric key
 |val | value | Number|
 
 ##### @delete()
+
 Click delete key
 
 ##### @confirm()
+
 Click confirmation key

--- a/src/packages/number-keyboard/README.md
+++ b/src/packages/number-keyboard/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(NumberKeyboard.name, NumberKeyboard)
 
 <demo-wrapper
   src="src/packages/number-keyboard/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/number-keyboard/demo/demo*.vue')
-</script>
 
 ## API
 
 ### NumberKeyboard Props
+
 |属性 | 说明 | 类型 | 默认值| 备注|
 |----|-----|------|------|------|
 |value|键盘是否展示|Boolean|`false`|-|
@@ -54,14 +50,17 @@ const demos = import.meta.globEager('../../../src/packages/number-keyboard/demo/
 ### NumberKeyboard Methods
 
 #### show()
+
 展示键盘
 
 #### hide()
+
 隐藏键盘
 
 ### NumberKeyboard Events
 
 #### @enter(val)
+
 数字键点击事件
 
 属性 | 说明 | 类型
@@ -69,7 +68,9 @@ const demos = import.meta.globEager('../../../src/packages/number-keyboard/demo/
 val     | 数字 | Number
 
 #### @delete()
+
 回退键点击事件
 
 #### @confirm()
+
 确认键点击事件

--- a/src/packages/picker/README.en-US.md
+++ b/src/packages/picker/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/picker
 
 # Picker
 
-
 Scrollable multi-column selector
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(Picker.name, Picker)
 
 <demo-wrapper
   src="src/packages/picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Picker Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model:visible|display picker or not|Boolean|`false`|-|
@@ -54,6 +47,7 @@ const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue
 #### Picker Methods
 
 ##### getColumnValue(index): activeItemValue
+
 Get the data of the currently selected item in a column
 
 |Parameters | Description | Type|
@@ -69,6 +63,7 @@ Returns
 #### Picker Events
 
 ##### @change(columnIndex, itemIndex, value)
+
 Change pickers' selections
 
 |Parameters | Description | Type|
@@ -78,15 +73,19 @@ Change pickers' selections
 |value|the value of changed item in the column|Object: {value, text, ...}|
 
 ##### @confirm()
+
 Confirm picker's selection (only when `is-view` is `false`）
 
 ##### @cancel()
+
 Cancel picker's selection (only when `is-view` is `false`）
 
 ##### @show()
+
 Show picker (only when `is-view` is `false`）
 
 ##### @hide()
+
 Hide picker (only when `is-view` is `false`）
 
 ### Appendix

--- a/src/packages/picker/README.md
+++ b/src/packages/picker/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Picker.name, Picker)
 
 <demo-wrapper
   src="src/packages/picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Picker Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |v-model:visible|选择器是否可见|Boolean|`false`|-|
@@ -51,6 +47,7 @@ const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue
 ### Picker Methods
 
 #### getColumnValues(): columnsValue
+
 获取所有列选中项的值
 
 返回
@@ -62,6 +59,7 @@ const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue
 ### Picker Events
 
 #### @change(columnIndex, itemIndex, value)
+
 选择器选中项更改事件
 
 |参数 | 说明 | 类型|
@@ -71,15 +69,19 @@ const demos = import.meta.globEager('../../../src/packages/picker/demo/demo*.vue
 |value|更改列选中项的的值|Object: {value, text, ...}|
 
 #### @confirm()
+
 选择器确认选择事件（仅`is-view`为`false`）
 
 #### @cancel()
+
 选择器取消选择事件（仅`is-view`为`false`）
 
 #### @show()
+
 选择器弹层展示事件（仅`is-view`为`false`）
 
 #### @hide()
+
 选择器弹层隐藏事件（仅`is-view`为`false`）
 
 ## 附录

--- a/src/packages/popup/README.en-US.md
+++ b/src/packages/popup/README.en-US.md
@@ -6,8 +6,8 @@ preview: https://didi.github.io/mand-mobile/examples/#/popup
 
 # Popup
 
-
 A customized content area slides out or pops up on the screen, triggered by other controls.
+
 ### Import
 
 ```javascript
@@ -21,18 +21,12 @@ Vue.createApp().component(PopupTitleBar.name, PopupTitleBar)
 
 <demo-wrapper
   src="src/packages/popup/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Popup Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|display popup or not|Boolean|`false`|-|
@@ -42,6 +36,7 @@ const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue'
 |transition|the animation effect of popup|String|-|`fade`, `fade-bounce`, `fade-slide`, `fade-zoom`<br> `slide-up`, `slide-down`, `slide-left`, `slide-right`|
 
 #### PopupTitleBar Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |title|title of popup|String|-|-|
@@ -55,21 +50,27 @@ const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue'
 #### Popup Events
 
 #### @beforeShow()
+
 Popup will be shown
 
 #### @show()
+
 Show popup
 
 #### @beforeHide()
+
 Popup will be hiden
 
 #### @hide()
+
 Hide popup
 
 #### PopupTitleBar Events
 
 ##### @confirm()
+
 Confirm selection
 
 ##### @cancel()
+
 Cancel selection

--- a/src/packages/popup/README.md
+++ b/src/packages/popup/README.md
@@ -21,16 +21,12 @@ Vue.createApp().component(PopupTitleBar.name, PopupTitleBar)
 
 <demo-wrapper
   src="src/packages/popup/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Popup Props
+
 |属性 | 说明 | 类型 | 默认值| 备注|
 |----|-----|------|------|------|
 |model-value|弹出层是否可见|Boolean|`false`| |
@@ -40,6 +36,7 @@ const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue'
 |transition|弹出层过渡动画|String|`fade`|`fade`, `fade-bounce`, `fade-slide`, `fade-zoom`<br> `slide-up`, `slide-down`, `slide-left`, `slide-right`|
 
 ### PopupTitleBar Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |title|标题|String| | |
@@ -52,21 +49,27 @@ const demos = import.meta.globEager('../../../src/packages/popup/demo/demo*.vue'
 ### Popup Events
 
 ### @beforeShow()
+
 弹出层即将展示事件
 
 ### @show()
+
 弹出层展示事件
 
 ### @beforeHide()
+
 弹出层即将隐藏事件
 
 ### @hide()
+
 弹出层隐藏事件
 
 ### PopupTitleBar Events
 
 #### @confirm()
+
 确认选择事件
 
 #### @cancel()
+
 取消选择事件

--- a/src/packages/progress/README.en-US.md
+++ b/src/packages/progress/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/progress
 
 # Progress
 
-
 Progress circle, generally used to communicate data intuitively to users
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(Progress.name, Progress)
 
 <demo-wrapper
   src="src/packages/progress/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/progress/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Progress Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |value|progress value|Number|`0`|`0-1`|
@@ -49,7 +42,9 @@ const demos = import.meta.globEager('../../../src/packages/progress/demo/demo*.v
 #### Progress Slots
 
 ##### default
+
 slot inside circle, generally used to add text
 
 ##### defs
+
 slot inside circle svg, generally used to add `defs`, `use` elements, etc

--- a/src/packages/progress/README.md
+++ b/src/packages/progress/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Progress.name, Progress)
 
 <demo-wrapper
   src="src/packages/progress/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/progress/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Progress Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |value|进度值|Number|`0`|`0-1`|
@@ -46,7 +42,9 @@ const demos = import.meta.globEager('../../../src/packages/progress/demo/demo*.v
 ### Progress Slots
 
 #### default
+
 圆环内部内容插槽，一般用于添加文本
 
 #### defs
+
 圆环SVG内部的插槽，一般用于添加`defs`, `use`元素等

--- a/src/packages/radio/README.en-US.md
+++ b/src/packages/radio/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/radio
 
 # Radio
 
-
 Customizable or editable radio buttons
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(Radio.name, Radio)
 
 <demo-wrapper
   src="src/packages/radio/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Radio Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |v-model|selected `name`|any|-|
@@ -48,8 +41,8 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 
 ---
 
-
 #### RadioBox Props
+
 Radio box <sup class="version-after">2.5.0+</sup>
 | Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
@@ -60,6 +53,7 @@ Radio box <sup class="version-after">2.5.0+</sup>
 ---
 
 #### RadioGroup Props
+
 Check multiple radios. Combine with `Radio` or `RadioBox` <sup class="version-after">2.5.0+</sup>
 
 | Props | Description | Type | Default | Note |
@@ -77,6 +71,7 @@ Check multiple radios. Combine with `Radio` or `RadioBox` <sup class="version-af
 ---
 
 #### Radio List Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|`value` of the selected item|any|-|-|
@@ -95,6 +90,7 @@ Check multiple radios. Combine with `Radio` or `RadioBox` <sup class="version-af
 #### Radio List Methods
 
 ##### select(value)
+
 Set selected value
 
 |Parameters | Description | Type |
@@ -104,6 +100,7 @@ Set selected value
 #### Radio List Events
 
 ##### @change(option, index)
+
 Selected option changed
 
 |Props | Description | Type |
@@ -112,6 +109,7 @@ Selected option changed
 |index|index of selected option|Number|
 
 #### Radio List Slots
+
 ```html
 <template>
   <md-radio-list :options="data">

--- a/src/packages/radio/README.md
+++ b/src/packages/radio/README.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/radio
 
 # Radio 单选框
 
-
 可自定义或编辑单选框
 
 ## 引入
@@ -20,24 +19,18 @@ Vue.createApp().component(RadioGroup.name, RadioGroup)
 Vue.createApp().component(RadioList.name, RadioList)
 ```
 
-
 ## 代码演示
 
 <demo-wrapper
   src="src/packages/radio/demo"
-  :demos="demos"
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue')
-</script>
-
 <!-- DEMO -->
-
 
 ## API
 
 ### Radio Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |value|选中项的`name`|any|-|
@@ -54,6 +47,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 ---
 
 ### RadioBox Props
+
 单选框
 
 |属性 | 说明 | 类型 | 默认值 | 备注 |
@@ -65,6 +59,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 ---
 
 ### RadioGroup Props
+
 单选组，用以选中多个单选项。与`Radio`或`RadioBox`组合使用
 
 |属性 | 说明 | 类型 | 默认值 | 备注 |
@@ -82,6 +77,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 ---
 
 ### Radio List Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |value|选中项的`value`|any|-|
@@ -100,6 +96,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 ### Radio List Methods
 
 #### select(value)
+
 设置选中项
 
 |参数 | 说明 | 类型|
@@ -109,6 +106,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 ### Radio List Events
 
 #### @change(option, index)
+
 切换选中项事件
 
 |属性 | 说明 | 类型|
@@ -117,6 +115,7 @@ const demos = import.meta.globEager('../../../src/packages/radio/demo/demo*.vue'
 |index|当前选中项的索引|Number|
 
 ### Radio List Slots
+
 ```html
 <template>
   <md-radio-list :options="data">

--- a/src/packages/result-page/README.en-US.md
+++ b/src/packages/result-page/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/result-page
 
 # ResultPage
 
-
 To display the process ending page
 
 ### Import
@@ -25,18 +24,14 @@ It is recommended to set the parent element filled with windows to achieve cente
 
 <demo-wrapper
   src="src/packages/result-page/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/result-page/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 
 ### API
 
 #### ResultPage Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |type | page type | String | `empty` | three optional vaules: `lost`, `network` and `empty`, represent missing page, network error and empty information respectively. The default images and texts of component differ according to the category|
@@ -46,6 +41,7 @@ const demos = import.meta.globEager('../../../src/packages/result-page/demo/demo
 |buttons | button list | Array | - | array of button objects, whose structure can be referred to `Button`|
 
 #### Button Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |text | button text | String | - | - |

--- a/src/packages/result-page/README.md
+++ b/src/packages/result-page/README.md
@@ -24,16 +24,12 @@ Vue.createApp().component(ResultPage.name, ResultPage)
 
 <demo-wrapper
   src="src/packages/result-page/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/result-page/demo/demo*.vue')
-</script>
 
 ## API
 
 ### ResultPage Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |type | 页面类别 | String | `empty` | type可取`lost`, `network`和`empty`三个值，分别代表页面丢失、网络出错和空信息。根据类别不同，组件会拥有不同的默认图片和文案|
@@ -43,6 +39,7 @@ const demos = import.meta.globEager('../../../src/packages/result-page/demo/demo
 |buttons | 按钮列表 | Array\<[ButtonOptions](#buttonoptions)\> |  | 按钮对象数组，按钮可参考`Button`|
 
 #### ButtonOptions
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |text | 按钮文字 | String | - | - |
@@ -58,4 +55,5 @@ const demos = import.meta.globEager('../../../src/packages/result-page/demo/demo
 ### ResultPage Events
 
 ### @action(button: [ButtonOptions](#buttonoptions))
+
 点击按钮时触发，也可以直接配置[ButtonOptions](#buttonoptions)中的handler

--- a/src/packages/scroll-view/README.en-US.md
+++ b/src/packages/scroll-view/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/scroll-view
 
 # ScrollView
 
-
 Used to simulate native scrolling areas and support pull-down refresh and load more
 
 ### Import
@@ -29,18 +28,14 @@ Vue.createApp().component(ScrollView.name, ScrollView)
 
 <demo-wrapper
   src="src/packages/scroll-view/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 
 ### API
 
 #### ScrollView Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |scrolling-x | horizontal scrolling | Boolean | `true` | -|
@@ -58,6 +53,7 @@ const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo
 <img src="https://pt-starimg.didistatic.com/static/starimg/img/cSL4mjxTmW1560240984431.jpg" width="460"/>
 
 #### ScrollViewRefresh Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |scroll-top | distance from top | Number | `0` | unit `px` |
@@ -69,6 +65,7 @@ const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo
 |roller-color <sup class="version-after">2.2.0+</sup>| progress bar color | String | `#2F86F6` | - |
 
 #### ScrollViewMore Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |is-finished | all loaded | Boolean | `false` | - |
@@ -78,9 +75,11 @@ const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo
 #### ScrollView Slots
 
 ##### default
+
 Scrolling area content slot. When the content changes, you need to call `reflowScroller` to reset the scroll area. Refer to <a href="javascript:jumpAnchor('reflowScroller')">reflowScroller</a>
 
 ##### refresh
+
 Pull-down refresh component slot, you can use `slot-scoped` to get the relevant scrolling status as follows (the scrolling state can also be dynamically set by event when the `slot-scoped` is not compatible)
 
 ```html
@@ -92,24 +91,31 @@ Pull-down refresh component slot, you can use `slot-scoped` to get the relevant 
   :is-refresh-active="isRefreshActive"
 ></md-scroll-view-refresh>
 ```
+
 ##### more
+
 load-more component slot
 
 ##### header
+
 header slot
 
 ##### footer
+
 footer slot
 
 #### ScrollView Methods
 
 ##### init()
+
 Initialize the scroll area, used when `manual-init` is set to `true`.
 
 ##### reflowScroller()
+
 Reset the scroll area, which needs to be called after the content in the general scroll area changes.
 
 ##### scrollTo(left, top, animate = false)
+
 Scroll to the specified location
 
 |Parameters | Description | Type|
@@ -119,20 +125,25 @@ Scroll to the specified location
 |animate|using animation|Boolean|
 
 ##### getOffsets(): {left: number, top: number}
+
 Get scrolling position <sup class="version-after">2.5.4+</sup>
 
 ##### triggerRefresh()
+
 -
 
 ##### finishRefresh()
+
 -
 
 ##### finishLoadMore()
+
 -
 
 #### ScrollView Events
 
 ##### @scroll({scrollLeft, scrollTop})
+
 Scrolling event
 
 |Props | Description | Type|
@@ -141,12 +152,15 @@ Scrolling event
 |scrollTop|distance from top|Number|
 
 ##### @refreshActive()
+
 Release refreshable event
 
 ##### @refreshing()
+
 Refreshing event
 
 ##### @end-reached()
+
 Reached end event
 
 ### Appendix

--- a/src/packages/scroll-view/README.md
+++ b/src/packages/scroll-view/README.md
@@ -19,22 +19,17 @@ Vue.createApp().component(PullUp.name, PullUp)
 ```
 
 ::: tip
+
 * `PullDown`为组件库内置的下拉刷新组件，仅用于作为视觉展示，需在插槽<a href="#pulldown">pulldown</a>中使用，下拉刷新组件也可自定义
 * `PullUp`为组件库内置的加载更多组件，仅用于作为视觉展示，需在插槽<a href="#pullup">pullup</a>中使用，加载更多组件也可自定义
 * **组件容器需具有高度，否则会出现无法滚动或回弹问题。** 更多使用的常见问题请查看<a href="#附录">附录</a>
 :::
 
-
 ## 代码演示
 
 <demo-wrapper
   src="src/packages/scroll-view/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo*.vue')
-</script>
 
 ## API
 
@@ -63,7 +58,6 @@ const demos = import.meta.globEager('../../../src/packages/scroll-view/demo/demo
 |roller-color| 进度条颜色 | String | `#2F86F6` | - |
 
 ### PullUp Props
-
 
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|

--- a/src/packages/selector/README.en-US.md
+++ b/src/packages/selector/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/selector
 
 # Selector
 
-
 For selecting an item from the popup list
 
 ### Import
@@ -21,19 +20,14 @@ Vue.createApp().component(Selector.name, Selector)
 
 <demo-wrapper
   src="src/packages/selector/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/selector/demo/demo*.vue')
-</script>
-
 
 <!-- DEMO -->
 
 ### API
 
 #### Selector Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|display selector or not|Boolean|false|-|
@@ -57,22 +51,26 @@ const demos = import.meta.globEager('../../../src/packages/selector/demo/demo*.v
 |icon-position|the position of icon|String|`right`|`left`, `right`|
 |multi<sup class="version-after">2.3.0+</sup>|support multi select|Boolean|`false`|`multi` must be with `ok-text` prop|
 
-
 #### Selector Events
 
 #### @choose({value, text, ...})
+
 Select one item
 
 #### @confirm({value, text, ...})
+
 Confirm selection
 
 #### @cancel()
+
 Cancel selection
 
 #### @show()
+
 Show selector
 
 #### @hide()
+
 Hide selector
 
 #### Selector Slots
@@ -89,8 +87,8 @@ Hide selector
 
 ##### header
 
-header slot <sup class="version-after">2.4.0+</sup>    
+header slot <sup class="version-after">2.4.0+</sup>
 
 ##### footer
 
-footer slot <sup class="version-after">2.4.0+</sup>     
+footer slot <sup class="version-after">2.4.0+</sup>

--- a/src/packages/selector/README.md
+++ b/src/packages/selector/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(Selector.name, Selector)
 
 <demo-wrapper
   src="src/packages/selector/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/selector/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/skeleton/README.en-US.md
+++ b/src/packages/skeleton/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/Skeleton
 
 # Skeleton
 
-
 Skeleton screen, generally used to display the loading state of the general structure of the page before the data has been loaded <sup class="version-after">2.5.0+</sup>
 
 ### Import
@@ -21,18 +20,14 @@ Vue.createApp().component(Skeleton.name, Skeleton)
 
 <demo-wrapper
   src="src/packages/skeleton/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/skeleton/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 
 ### API
 
 #### Skeleton Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |loading|display the skeleton loading |Boolean|true|-|

--- a/src/packages/skeleton/README.md
+++ b/src/packages/skeleton/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Skeleton.name, Skeleton)
 
 <demo-wrapper
   src="src/packages/skeleton/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/skeleton/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Skeleton Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |loading|是否显示骨架屏|Boolean|true|-|

--- a/src/packages/slider/README.en-US.md
+++ b/src/packages/slider/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/slider
 
 # Slider
 
-
 ### Import
 
 ```javascript
@@ -19,18 +18,12 @@ Vue.createApp().component(Slider.name, Slider)
 
 <demo-wrapper
   src="src/packages/slider/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/slider/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Slider Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|the value of slider, when <code>range</code> is false, use <code>number</code>, otherwise, use <code>[number, number]</code>|number , number[]|`0`|-|

--- a/src/packages/slider/README.md
+++ b/src/packages/slider/README.md
@@ -18,17 +18,12 @@ Vue.createApp().component(Slider.name, Slider)
 
 <demo-wrapper
   src="src/packages/slider/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/slider/demo/demo*.vue')
-</script>
-
 
 ## API
 
 ### Slider Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |value|双向绑定的值|number/number[]|`0`|当开启 range 时, 其值为数组形式|

--- a/src/packages/stepper/README.en-US.md
+++ b/src/packages/stepper/README.en-US.md
@@ -21,12 +21,10 @@ Vue.createApp().component(Stepper.name, Stepper)
 
 <demo-wrapper
   src="src/packages/stepper/demo"
-  :demos="demos"
+  
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/stepper/demo/demo*.vue')
-</script>
+
 
 <!-- DEMO -->
 

--- a/src/packages/stepper/README.md
+++ b/src/packages/stepper/README.md
@@ -20,12 +20,10 @@ Vue.createApp().component(Stepper.name, Stepper)
 
 <demo-wrapper
   src="src/packages/stepper/demo"
-  :demos="demos"
+  
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/stepper/demo/demo*.vue')
-</script>
+
 
 ## API
 

--- a/src/packages/steps/README.en-US.md
+++ b/src/packages/steps/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/steps
 
 # Steps
 
-
 A navigation bar helps users complete tasks through the process and displays the current step
 
 ### Import
@@ -21,25 +20,19 @@ Vue.createApp().component(Steps.name, Steps)
 
 <demo-wrapper
   src="src/packages/steps/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/steps/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Steps Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |steps|array of step information|Array<{name, text}>|-|-|
 |current|current step|Number|`0`|support for decimal point|
 |direction| to specify the direction of the step bar|String|`horizontal`|`horizontal`, `vertical`|
 |transition|progress change transition|Boolean|`false`|-|
-|vertical-adaptive|step height adaptive|Boolean|`false`|only for `vertical`, ** if set to `true` then adaptive according to container height, setting `.mfe-steps` height is necessary**|
+|vertical-adaptive|step height adaptive|Boolean|`false`|only for `vertical`, **if set to `true` then adaptive according to container height, setting `.mfe-steps` height is necessary**|
 
 #### Steps Slots
 

--- a/src/packages/steps/README.md
+++ b/src/packages/steps/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Steps.name, Steps)
 
 <demo-wrapper
   src="src/packages/steps/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/steps/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Steps Props
+
 | 属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |steps|步骤信息数组|Array\<[StepOptions](#stepoptions)\>| | |
@@ -40,6 +36,7 @@ const demos = import.meta.globEager('../../../src/packages/steps/demo/demo*.vue'
 |adaptive|步骤高度自适应|Boolean|`false`|仅用于`vertical`, **如果设置为`true`则根据容器高度自适应，需设置`.mfe-steps`高度**|
 
 ### StepOptions
+
 | 属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |name|步骤标题|String| | |

--- a/src/packages/swiper/README.en-US.md
+++ b/src/packages/swiper/README.en-US.md
@@ -6,9 +6,7 @@ preview: https://didi.github.io/mand-mobile/examples/#/swiper
 
 # Swiper
 
-
 Carousel, used to cycle through a set of pictures or cards
-
 
 ### Import
 
@@ -23,14 +21,7 @@ Vue.createApp().component(SwiperItem.name, SwiperItem)
 
 <demo-wrapper
   src="src/packages/swiper/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/swiper/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
@@ -51,6 +42,7 @@ const demos = import.meta.globEager('../../../src/packages/swiper/demo/demo*.vue
 #### Swiper Methods
 
 ##### play(autoplay)
+
 enable autoplay
 
 | Args | Description | Type | Default | Note |
@@ -62,6 +54,7 @@ vm.$refs.swiper.play(5000)
 ```
 
 ##### stop()
+
 stop autoplay
 
 ```js
@@ -69,6 +62,7 @@ vm.$refs.swiper.stop()
 ```
 
 ##### prev()
+
 switch to the previous item
 
 ```js
@@ -76,6 +70,7 @@ vm.$refs.swiper.prev()
 ```
 
 ##### next()
+
 switch to the next item
 
 ```js
@@ -83,6 +78,7 @@ vm.$refs.swiper.next()
 ```
 
 ##### goto(index)
+
 switch to `index`
 
 | Args | Description | Type | Default | Note |
@@ -94,6 +90,7 @@ vm.$refs.swiper.goto(2)
 ```
 
 ##### getIndex()
+
 get the index on display
 
 | Args | Description | Type |
@@ -105,7 +102,9 @@ var index = vm.$refs.swiper.getIndex()
 ```
 
 #### Swiper Events
+
 ##### @beforeChange(from, to)
+
 event to be triggered before the slide is changed
 
 | Args | Description | Type |
@@ -114,6 +113,7 @@ event to be triggered before the slide is changed
 | to     | the next index | Number          |
 
 ##### @afterChange(from, to)
+
 event to be triggered after the slide is changed
 
 | Args | Description | Type |

--- a/src/packages/swiper/README.md
+++ b/src/packages/swiper/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(Swiper.name, Swiper)
 
 <demo-wrapper
   src="src/packages/swiper/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/swiper/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/switch/README.en-US.md
+++ b/src/packages/switch/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/switch
 
 # Switch
 
-
 Switch between two status
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(Switch.name, Switch)
 
 <demo-wrapper
   src="src/packages/switch/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/switch/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Switch Props
+
 | Props | Description | Type | Default |
 |----|-----|------|------|
 |v-model| Whether it is on or off |Boolean|`false`|

--- a/src/packages/switch/README.md
+++ b/src/packages/switch/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(Switch.name, Switch)
 
 <demo-wrapper
   src="src/packages/switch/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/switch/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Switch Props
+
 |属性 | 说明 | 类型 | 默认值|
 |----|-----|------|------|
 |value|打开或者关闭|Boolean|`false`|
@@ -38,6 +34,7 @@ const demos = import.meta.globEager('../../../src/packages/switch/demo/demo*.vue
 ### Switch Events
 
 #### @change(isActive)
+
 事件说明
 
 |属性 | 说明 | 类型 |

--- a/src/packages/tab-bar/README.en-US.md
+++ b/src/packages/tab-bar/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/tab-bar
 
 # TabBar
 
-
 To create a tab bar without a content area
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(TabBar.name, TabBar)
 
 <demo-wrapper
   src="src/packages/tab-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tab-bar/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### TabBar Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 | v-model | key of selected menu | String | - | - |
@@ -44,11 +37,13 @@ const demos = import.meta.globEager('../../../src/packages/tab-bar/demo/demo*.vu
 #### TabBar Methods
 
 ##### reflow(index)
+
 relayout tabbar
 
 #### TabBar Events
 
 ##### @change(item, index, prevIndex)
+
 selected menu index changes
 
 |Props | Description | Type|
@@ -58,6 +53,7 @@ selected menu index changes
 | index | index of previous selected menu | Number |
 
 #### TabBar Slot
+
 ```javascript
 <md-tab-bar>
   <template slot="item" slot-scope="{ item, currentName, index, items }">

--- a/src/packages/tab-bar/README.md
+++ b/src/packages/tab-bar/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(TabBar.name, TabBar)
 
 <demo-wrapper
   src="src/packages/tab-bar/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tab-bar/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/tab-picker/README.en-US.md
+++ b/src/packages/tab-picker/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/tab-picker
 
 # TabPicker
 
-
 Support cascaded selections in the footer
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(TabPicker.name, TabPicker)
 
 <demo-wrapper
   src="src/packages/tab-picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### TabPicker Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|whether to show tabpicker or not|Boolean|`false`|-|
@@ -46,6 +39,7 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 #### TabPicker Methods
 
 ##### getSelectedValues()
+
 Get all values of selected items
 
 ```
@@ -53,6 +47,7 @@ Get all values of selected items
 ```
 
 #### getSelectedOptions()
+
 Get all options of selected items
 
 ```
@@ -66,6 +61,7 @@ Get all options of selected items
 #### TabPicker Events
 
 ##### @select(data)
+
 Option selected event
 
 ```
@@ -78,6 +74,7 @@ Option selected event
 ```
 
 ##### @change(data)
+
 Change selection in the tabpicker
 
 ```
@@ -93,12 +90,15 @@ Change selection in the tabpicker
 ```
 
 ##### @show()
+
 Show tabPicker
 
 ##### @hide()
+
 Hide tabPicker
 
 #### TabPicker Slots
+
 Custom option item slot
 
 ```

--- a/src/packages/tab-picker/README.md
+++ b/src/packages/tab-picker/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(TabPicker.name, TabPicker)
 
 <demo-wrapper
   src="src/packages/tab-picker/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*.vue')
-</script>
 
 ## API
 
 ### TabPicker 参数
+
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |value|控制显示或隐藏|Boolean|`false`| |
@@ -40,10 +36,10 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 |placeholder|默认提示文本|String|`请选择`| |
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`| |
 
-
 ### TabPicker 实例方法
 
 #### getSelectedValues()
+
 获取所有面板选中项的值
 
 ```
@@ -51,6 +47,7 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 ```
 
 #### getSelectedOptions()
+
 获取所有面板选中项对象
 
 ```
@@ -64,6 +61,7 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 ### TabPicker 事件
 
 #### @select(data)
+
 选项选中事件
 
 ```
@@ -76,6 +74,7 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 ```
 
 #### @change(data)
+
 底部弹窗选中事件
 
 ```
@@ -91,12 +90,15 @@ const demos = import.meta.globEager('../../../src/packages/tab-picker/demo/demo*
 ```
 
 #### @show()
+
 底部弹窗弹层展示事件
 
 #### @hide()
+
 底部弹窗弹层隐藏事件
 
 ### TabPicker 插槽
+
 选项插槽自定义
 
 ```

--- a/src/packages/tabs/README.en-US.md
+++ b/src/packages/tabs/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/tabs
 
 # Tabs
 
-
 To create a tab page with a content area
 
 ### Import
@@ -22,24 +21,19 @@ Vue.createApp().component(TabPane.name, TabPane)
 
 <demo-wrapper
   src="src/packages/tabs/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tabs/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Tabs Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |v-model|name of selected tab|String|-|-|
 |immediate|trigger a `change` event immediately after initialization|Boolean|`false`|-|
 
 #### TabPane Props
+
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
 |name|unique name|String|-|required|
@@ -49,11 +43,13 @@ const demos = import.meta.globEager('../../../src/packages/tabs/demo/demo*.vue')
 #### Tabs Methods
 
 ##### reflowTabBar()
+
 relayout tabbar
 
 #### Tabs Events
 
 ##### @change(tab)
+
 when user select tab
 
 |Props | Description | Type|

--- a/src/packages/tabs/README.md
+++ b/src/packages/tabs/README.md
@@ -21,12 +21,7 @@ Vue.createApp().component(TabPane.name, TabPane)
 
 <demo-wrapper
   src="src/packages/tabs/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tabs/demo/demo*.vue')
-</script>
 
 ## API
 

--- a/src/packages/tag/README.en-US.md
+++ b/src/packages/tag/README.en-US.md
@@ -6,8 +6,7 @@ preview: https://didi.github.io/mand-mobile/examples/#/tag
 
 # Tag
 
-
-For showing the area status 
+For showing the area status
 
 ### Import
 
@@ -21,18 +20,14 @@ Vue.createApp().component(Tag.name, Tag)
 
 <demo-wrapper
   src="src/packages/tag/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tag/demo/demo*.vue')
-</script>
 
 <!-- DEMO -->
 
 ### API
 
 #### Tag Props
+
 | Props | Description | Type | Default | Value |
 |----|-----|------|------|------|
 |size| size of tag  |String|`large`|`tiny`, `small`, `large`|

--- a/src/packages/tag/README.md
+++ b/src/packages/tag/README.md
@@ -20,12 +20,7 @@ Vue.createApp().component(Tag.name, Tag)
 
 <demo-wrapper
   src="src/packages/tag/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tag/demo/demo*.vue')
-</script>
 
 <style>
   .demo-wrapper .md-tag {
@@ -36,6 +31,7 @@ const demos = import.meta.globEager('../../../src/packages/tag/demo/demo*.vue')
 ## API
 
 ### Tag Props
+
 |属性 | 说明 | 类型 | 默认值 |可选值|
 |----|-----|------|------|------|
 |size|标签大小|String|`large`|`tiny`, `small`, `large`|

--- a/src/packages/textarea-item/README.en-US.md
+++ b/src/packages/textarea-item/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/TextareaItem
 
 # TextareaItem
 
-
 Multi-line text input <sup class="version-after">2.5.0+</sup>
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(TextareaItem.name, TextareaItem)
 
 <demo-wrapper
   src="src/packages/textarea-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/textarea-item/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### TextareaItem Props
+
 | Props                                             | Description                                     | Type          | Default | Note               |
 | ------------------------------------------------- | ----------------------------------------------- | ------------- | ------- | ------------------ |
 | title                                             | title of textarea                               | String        | -       | -                  |
@@ -57,27 +50,35 @@ the slot of footer
 #### TextareaItem Events
 
 ##### focus()
+
 Input gets focus
 
 ##### blur()
+
 Input loses focus
 
 ##### getValue()
+
 Get value of input
 
 #### TextItem Events
 
 ##### @focus(name)
+
 Textarea gets focus
 
 ##### @blur(name)
+
 Textarea loses blur
 
 ##### @change(name, value)
+
 Change the value of Textarea
 
 ##### @keyup(name, event)
+
 key press
 
 ##### @keydown(name, event)
+
 key release

--- a/src/packages/textarea-item/README.md
+++ b/src/packages/textarea-item/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(TextareaItem.name, TextareaItem)
 
 <demo-wrapper
   src="src/packages/textarea-item/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/textarea-item/demo/demo*.vue')
-</script>
 
 ## API
 
 ### TextareaItem Props
+
 | 属性                                              | 说明                                             | 类型          | 默认值  | 备注           |
 | ------------------------------------------------- | ------------------------------------------------ | ------------- | ------- | -------------- |
 | title                                             | 标题                                             | String        | -       | -              |
@@ -54,27 +50,35 @@ const demos = import.meta.globEager('../../../src/packages/textarea-item/demo/de
 ### TextareaItem Events
 
 #### focus()
+
 文本域获得焦点
 
 #### blur()
+
 文本域失去焦点
 
 #### getValue()
+
 获取文本域值
 
 ### TextItem Events
 
 #### @focus(name)
+
 文本域获得焦点事件
 
 #### @blur(name)
+
 文本域失去焦点事件
 
 #### @change(name, value)
+
 文本域值变化事件
 
 #### @keyup(name, event)
+
 文本域按键按下事件
 
 #### @keydown(name, event)
+
 文本域按键释放事件

--- a/src/packages/tip/README.en-US.md
+++ b/src/packages/tip/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/tip
 
 # Tip
 
-
 Tooltip
 
 ### Import
@@ -21,18 +20,12 @@ Vue.createApp().component(Tip.name, Tip)
 
 <demo-wrapper
   src="src/packages/tip/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tip/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Tip Props
+
 | Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |name|the name of tip|String/Number|-|generally used for special class names|
@@ -46,7 +39,9 @@ const demos = import.meta.globEager('../../../src/packages/tip/demo/demo*.vue')
 #### Tip Events
 
 ##### @show()
+
 Invoked after dialog is shown
 
 ##### @hide()
+
 Invoked after dialog is hidden

--- a/src/packages/tip/README.md
+++ b/src/packages/tip/README.md
@@ -14,21 +14,16 @@ import { Tip } from 'mand-mobile-next'
 Vue.createApp().component(Tip.name, Tip)
 ```
 
-
 ## 代码演示
 
 <demo-wrapper
   src="src/packages/tip/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/tip/demo/demo*.vue')
-</script>
 
 ## API
 
 ### Tip Props
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 |name|提示名称|String\/Number| |一般用于特殊类名|
@@ -42,7 +37,9 @@ const demos = import.meta.globEager('../../../src/packages/tip/demo/demo*.vue')
 ### Tip Events
 
 #### @show()
+
 提示框显示后触发的事件
 
 #### @hide()
+
 提示框隐藏后触发的事件

--- a/src/packages/toast/README.en-US.md
+++ b/src/packages/toast/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/toast
 
 # Toast
 
-
 ### Import
 
 ```javascript
@@ -25,20 +24,14 @@ Vue.createApp().component(Toast.name, Toast) // Component Import
 
 <demo-wrapper
   src="src/packages/toast/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### Toast Static Methods
 
 ##### Toast.create({content, icon, iconSvg, duration, position, hasMask, parentNode})
+
 Dynamically create a toast
 
 | Props | Description | Type | Default | Note |
@@ -52,6 +45,7 @@ Dynamically create a toast
 | parentNode | portal node of toast | HTMLElement | `document.body`| - |
 
 ##### Toast.info(content, duration, hasMask, parentNode)
+
 Dynamically create a text toast
 
 | Props | Description | Type | Default | Note |
@@ -62,6 +56,7 @@ Dynamically create a text toast
 | parentNode | portal node of toast | HTMLElement | `document.body`| - |
 
 ##### Toast.succeed(content, duration, hasMask, parentNode)
+
 Dynamically create a success toast
 
 | Props | Description | Type | Default | Note |
@@ -72,6 +67,7 @@ Dynamically create a success toast
 | parentNode | portal node of toast | HTMLElement | `document.body`| - |
 
 ##### Toast.failed(content, duration, hasMask, parentNode)
+
 Dynamically create a failed toast
 
 | Props | Description | Type | Default | Note |
@@ -82,6 +78,7 @@ Dynamically create a failed toast
 | parentNode | portal node of toast | HTMLElement | `document.body`| - |
 
 ##### Toast.loading(content, duration, hasMask, parentNode)
+
 Dynamically create a loading toast
 
 | Props | Description | Type | Default | Note |
@@ -92,6 +89,7 @@ Dynamically create a loading toast
 | parentNode | portal node of toast | HTMLElement | `document.body`| - |
 
 ##### Toast.hide()
+
 Hide current toast
 
 #### Toast.component Props
@@ -118,9 +116,11 @@ Hide current toast
 <sup class="version-after">2.3.0+</sup>
 
 ##### show()
+
 Show toast
 
 ##### hide()
+
 Hide toast
 
 #### Toast.component Events
@@ -128,7 +128,9 @@ Hide toast
 <sup class="version-after">2.3.0+</sup>
 
 ##### @show()
+
 Toast show event
 
 ##### @hide()
+
 Toast hidden event

--- a/src/packages/toast/README.md
+++ b/src/packages/toast/README.md
@@ -24,17 +24,11 @@ Vue.createApp().component(Toast.name, Toast) // 组件引入
 
 <demo-wrapper
   src="src/packages/toast/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue')
-</script>
 
 ## API
 
-
-### Toast Props 
+### Toast Props
 
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
@@ -48,17 +42,21 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 ### Toast Methods
 
 #### show()
+
 展示提示
 
 #### hide()
+
 隐藏提示
 
 ### Toast Events
 
 #### @show()
+
 提示展示事件
 
 #### @hide()
+
 提示隐藏事件
 
 ### 示例
@@ -74,9 +72,11 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 ### Toast Static Methods
 
 #### Toast.create(ToastOptions)
+
 显示自定义提示
 
 ##### ToastOptions
+
 |属性 | 说明 | 类型 | 默认值|备注|
 |----|-----|------|------|------|
 | icon | Icon组件图标名称 | String | - |如需自定义图标, 请查看`Icon`组件 |
@@ -88,6 +88,7 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 | parentNode | 组件挂载节点 | HTMLElement | `document.body`|- |
 
 #### Toast.info(content, duration, hasMask, parentNode)
+
 显示纯文本提示
 
 |属性 | 说明 | 类型 | 默认值|
@@ -98,6 +99,7 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 | parentNode | 组件挂载节点 | HTMLElement | `document.body` |
 
 #### Toast.succeed(content, duration, hasMask, parentNode)
+
 显示成功提示
 
 |属性 | 说明 | 类型 | 默认值|
@@ -108,6 +110,7 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 | parentNode | 组件挂载节点 | HTMLElement | `document.body` |
 
 #### Toast.failed(content, duration, hasMask, parentNode)
+
 显示失败提示
 
 |属性 | 说明 | 类型 | 默认值|
@@ -118,6 +121,7 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 | parentNode | 组件挂载节点 | HTMLElement | `document.body`|
 
 #### Toast.loading(content, duration, hasMask, parentNode)
+
 显示载入提示
 
 |属性 | 说明 | 类型 | 默认值|
@@ -128,4 +132,5 @@ const demos = import.meta.globEager('../../../src/packages/toast/demo/demo*.vue'
 | parentNode | 组件挂载节点 | HTMLElement | `document.body`|
 
 #### Toast.hide()
+
 隐藏提示

--- a/src/packages/transition/README.en-US.md
+++ b/src/packages/transition/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/transition
 
 # Transition
 
-
 复用动画切换组件
 
 ### 引入
@@ -18,9 +17,13 @@ Vue.createApp().component(Transition.name, Transition)
 ```
 
 ### 代码演示
-<!-- DEMO -->
+
+<demo-wrapper
+  src="src/packages/transition/demo"
+/>
 
 ### API
+
 `md-transition` is a wrapper of vue `transtion`, support all `transition` props.
 
 built-in transition name：
@@ -37,4 +40,3 @@ built-in transition name：
 - `md-bounce`
 - `md-punch`
 - `md-zoom`
-

--- a/src/packages/transition/README.md
+++ b/src/packages/transition/README.md
@@ -20,14 +20,10 @@ Vue.createApp().component(Transition.name, Transition)
 
 <demo-wrapper
   src="src/packages/transition/demo"
-  :demos="demos"
 />
 
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/transition/demo/demo*.vue')
-</script>
-
 ## API
+
 `md-transition`组件为Vue内置`transtion`的一层封装，支持所有Transition的属性参数。
 
 其中内置动画`name`参数如下：
@@ -44,4 +40,3 @@ const demos = import.meta.globEager('../../../src/packages/transition/demo/demo*
 - `md-bounce`
 - `md-punch`
 - `md-zoom`
-

--- a/src/packages/water-mark/README.en-US.md
+++ b/src/packages/water-mark/README.en-US.md
@@ -6,7 +6,6 @@ preview: https://didi.github.io/mand-mobile/examples/#/water-mark
 
 # WaterMark
 
-
 Container with watermark background
 
 ### Instruction
@@ -21,18 +20,12 @@ Vue.createApp().component(WaterMark.name, WaterMark)
 
 <demo-wrapper
   src="src/packages/water-mark/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/water-mark/demo/demo*.vue')
-</script>
-
-<!-- DEMO -->
 
 ### API
 
 #### WaterMark Props
+
 |Props | Description | Type | Default | Note |
 |----|-----|------|------ |------|
 |content|-|String|-|complex content using `scoped slot`|
@@ -45,9 +38,11 @@ const demos = import.meta.globEager('../../../src/packages/water-mark/demo/demo*
 #### WaterMark Slots
 
 ##### default
+
 Default slot of content
 
 ##### watermark
+
 scoped slot of watermark content
 
 ```html

--- a/src/packages/water-mark/README.md
+++ b/src/packages/water-mark/README.md
@@ -20,16 +20,12 @@ Vue.createApp().component(WaterMask.name, WaterMark)
 
 <demo-wrapper
   src="src/packages/water-mark/demo"
-  :demos="demos"
 />
-
-<script setup>
-const demos = import.meta.globEager('../../../src/packages/water-mark/demo/demo*.vue')
-</script>
 
 ## API
 
 ### WaterMask Props
+
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------ |------|
 |content|水印内容|String| |复杂内容使用`scoped slot`|
@@ -42,9 +38,11 @@ const demos = import.meta.globEager('../../../src/packages/water-mark/demo/demo*
 ### WaterMark Slots
 
 #### default
+
 默认内容插槽
 
 #### watermark
+
 水印内容scoped插槽
 
 ```html


### PR DESCRIPTION
- [x] change demo write style in docs, more easier to import demo
  **Pre:** 
  ```vue
  <demo-wrapper
    src="src/packages/action-bar/demo"
    :demos="demos"
  />
  
  <script setup>
  const demos = import.meta.globEager('../../../src/packages/action-bar/demo/demo*.vue')
  </script>
  ```
  **After:** 
   ```vue
    <demo-wrapper src="src/packages/action-bar/demo" />
   ```